### PR TITLE
docs: add esbuild Stimulus setup guide for non-importmap apps; bump t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3] - 2026-03-17
+## [0.1.5] - 2026-03-17
+
+### Added
+- `docs/installation.md`: new **Section 5.2** — step-by-step guide for loading FlatPack Stimulus controllers in non-importmap apps (esbuild, Webpack, Vite, or any custom JS build pipeline).
+  - `scripts/build_stimulus.js` build script that dynamically resolves the FlatPack gem path via `bundle show flat_pack` and bundles all controllers into a self-contained IIFE using esbuild.
+  - Registers all 45 FlatPack Stimulus controllers by default (accordion, alert, badge, button-dropdown, carousel, chart, chat-*, chip, code-block-tabs, collapse, content-editor, date-input, file-input, form-validation, grid-sortable, icon, list-selectable, modal, navbar, pagination-infinite, password-input, picker, popover, range-input, search, search-input, section-title-anchor, select, sidebar, sidebar-group, sidebar-layout, table, table-sortable, tabs, text-area, theme, tiptap, toast, toasts-region, tooltip).
+  - `package.json` `build:stimulus` script for easy regeneration after `bundle update flat_pack`.
+  - Layout include instruction and localStorage key override note for `flat-pack--sidebar-layout`.
+- `docs/installation.md`: new troubleshooting entry **"Sidebar / Interactive Components Not Working (Non-Importmap Apps)"** — explains the root cause (controller never registered), links to Section 5.2, and provides a browser console verification step.
+
+
 
 ### Added
 - `FlatPack::ContentEditor::Component` — new in-place rich-text editor component that renders an editable content region with Edit / Save / Cancel controls and an optional floating balloon toolbar.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.4)
+    flat_pack (0.1.5)
       pagy (~> 9.0)
       rails (~> 8.0)
       tailwind_merge (~> 0.13)
@@ -411,7 +411,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.4)
+  flat_pack (0.1.5)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -234,6 +234,197 @@ If you need to manually configure the JavaScript controllers:
    lazyLoadControllersFrom("controllers/flat_pack", application)
    ```
 
+### 5.2 JavaScript Controllers — esbuild / Custom Build Pipeline (Non-Importmap Apps)
+
+The automatic install generator configures FlatPack controllers for **importmap-based** apps only. If your app uses **esbuild, Webpack, Vite, or any other bundler**, the FlatPack Stimulus controllers will **not** be loaded automatically — and interactive components such as the sidebar collapse/expand, modals, popovers, tooltips, and tabs will silently fail.
+
+**Root cause:** The `flat-pack--sidebar-layout` controller (and all other FlatPack Stimulus controllers) must be explicitly imported and registered in a bundled app. The importmap setup serves each controller file individually via Rails' asset pipeline; a custom bundler bypasses this entirely.
+
+#### 1. Install npm dependencies
+
+```bash
+npm install --save-dev @hotwired/stimulus esbuild
+```
+
+#### 2. Create a build script
+
+Create `scripts/build_stimulus.js` in your app root (create the `scripts/` directory if it does not exist):
+
+```javascript
+// scripts/build_stimulus.js
+// Dynamically resolves the FlatPack gem path so the bundle always uses the
+// currently-installed version. This is critical for git-sourced gems whose
+// path contains a hash (e.g. flat_pack-abc1234/).
+const { execSync, spawnSync } = require("child_process")
+const { writeFileSync, mkdirSync } = require("fs")
+const path = require("path")
+
+const flatpackRoot = execSync("bundle show flat_pack").toString().trim()
+const controllersDir = path.join(flatpackRoot, "app/javascript/flat_pack/controllers")
+
+// Import all FlatPack controllers.
+const entry = `
+import { Application } from "@hotwired/stimulus";
+import AccordionController        from "${controllersDir}/accordion_controller.js";
+import AlertController            from "${controllersDir}/alert_controller.js";
+import BadgeController            from "${controllersDir}/badge_controller.js";
+import ButtonDropdownController   from "${controllersDir}/button_dropdown_controller.js";
+import CarouselController         from "${controllersDir}/carousel_controller.js";
+import ChartController            from "${controllersDir}/chart_controller.js";
+import ChatGroupingController     from "${controllersDir}/chat_grouping_controller.js";
+import ChatImageDeckController    from "${controllersDir}/chat_image_deck_controller.js";
+import ChatMessageActionsController from "${controllersDir}/chat_message_actions_controller.js";
+import ChatScrollController       from "${controllersDir}/chat_scroll_controller.js";
+import ChatSenderController       from "${controllersDir}/chat_sender_controller.js";
+import ChipController             from "${controllersDir}/chip_controller.js";
+import CodeBlockTabsController    from "${controllersDir}/code_block_tabs_controller.js";
+import CollapseController         from "${controllersDir}/collapse_controller.js";
+import ContentEditorController    from "${controllersDir}/content_editor_controller.js";
+import DateInputController        from "${controllersDir}/date_input_controller.js";
+import FileInputController        from "${controllersDir}/file_input_controller.js";
+import FormValidationController   from "${controllersDir}/form_validation_controller.js";
+import GridSortableController     from "${controllersDir}/grid_sortable_controller.js";
+import IconController             from "${controllersDir}/icon_controller.js";
+import ListSelectableController   from "${controllersDir}/list_selectable_controller.js";
+import ModalController            from "${controllersDir}/modal_controller.js";
+import NavbarController           from "${controllersDir}/navbar_controller.js";
+import PaginationInfiniteController from "${controllersDir}/pagination_infinite_controller.js";
+import PasswordInputController    from "${controllersDir}/password_input_controller.js";
+import PickerController           from "${controllersDir}/picker_controller.js";
+import PopoverController          from "${controllersDir}/popover_controller.js";
+import RangeInputController       from "${controllersDir}/range_input_controller.js";
+import SearchController           from "${controllersDir}/search_controller.js";
+import SearchInputController      from "${controllersDir}/search_input_controller.js";
+import SectionTitleAnchorController from "${controllersDir}/section_title_anchor_controller.js";
+import SelectController           from "${controllersDir}/select_controller.js";
+import SidebarController          from "${controllersDir}/sidebar_controller.js";
+import SidebarGroupController     from "${controllersDir}/sidebar_group_controller.js";
+import SidebarLayoutController    from "${controllersDir}/sidebar_layout_controller.js";
+import TableController            from "${controllersDir}/table_controller.js";
+import TableSortableController    from "${controllersDir}/table_sortable_controller.js";
+import TabsController             from "${controllersDir}/tabs_controller.js";
+import TextAreaController         from "${controllersDir}/text_area_controller.js";
+import ThemeController            from "${controllersDir}/theme_controller.js";
+import TiptapController           from "${controllersDir}/tiptap_controller.js";
+import ToastController            from "${controllersDir}/toast_controller.js";
+import ToastsRegionController     from "${controllersDir}/toasts_region_controller.js";
+import TooltipController          from "${controllersDir}/tooltip_controller.js";
+
+const application = Application.start();
+application.register("flat-pack--accordion",           AccordionController);
+application.register("flat-pack--alert",               AlertController);
+application.register("flat-pack--badge",               BadgeController);
+application.register("flat-pack--button-dropdown",     ButtonDropdownController);
+application.register("flat-pack--carousel",            CarouselController);
+application.register("flat-pack--chart",               ChartController);
+application.register("flat-pack--chat-grouping",       ChatGroupingController);
+application.register("flat-pack--chat-image-deck",     ChatImageDeckController);
+application.register("flat-pack--chat-message-actions", ChatMessageActionsController);
+application.register("flat-pack--chat-scroll",         ChatScrollController);
+application.register("flat-pack--chat-sender",         ChatSenderController);
+application.register("flat-pack--chip",                ChipController);
+application.register("flat-pack--code-block-tabs",     CodeBlockTabsController);
+application.register("flat-pack--collapse",            CollapseController);
+application.register("flat-pack--content-editor",      ContentEditorController);
+application.register("flat-pack--date-input",          DateInputController);
+application.register("flat-pack--file-input",          FileInputController);
+application.register("flat-pack--form-validation",     FormValidationController);
+application.register("flat-pack--grid-sortable",       GridSortableController);
+application.register("flat-pack--icon",                IconController);
+application.register("flat-pack--list-selectable",     ListSelectableController);
+application.register("flat-pack--modal",               ModalController);
+application.register("flat-pack--navbar",              NavbarController);
+application.register("flat-pack--pagination-infinite", PaginationInfiniteController);
+application.register("flat-pack--password-input",      PasswordInputController);
+application.register("flat-pack--picker",              PickerController);
+application.register("flat-pack--popover",             PopoverController);
+application.register("flat-pack--range-input",         RangeInputController);
+application.register("flat-pack--search",              SearchController);
+application.register("flat-pack--search-input",        SearchInputController);
+application.register("flat-pack--section-title-anchor", SectionTitleAnchorController);
+application.register("flat-pack--select",              SelectController);
+application.register("flat-pack--sidebar",             SidebarController);
+application.register("flat-pack--sidebar-group",       SidebarGroupController);
+application.register("flat-pack--sidebar-layout",      SidebarLayoutController);
+application.register("flat-pack--table",               TableController);
+application.register("flat-pack--table-sortable",      TableSortableController);
+application.register("flat-pack--tabs",                TabsController);
+application.register("flat-pack--text-area",           TextAreaController);
+application.register("flat-pack--theme",               ThemeController);
+application.register("flat-pack--tiptap",              TiptapController);
+application.register("flat-pack--toast",               ToastController);
+application.register("flat-pack--toasts-region",       ToastsRegionController);
+application.register("flat-pack--tooltip",             TooltipController);
+`.trim()
+
+const tmpDir = path.join(__dirname, "../tmp")
+mkdirSync(tmpDir, { recursive: true })
+const entryPath = path.join(tmpDir, "flatpack_stimulus_entry.js")
+writeFileSync(entryPath, entry)
+
+const result = spawnSync(
+  "npx",
+  [
+    "esbuild", entryPath,
+    "--bundle",
+    "--format=iife",
+    "--outfile=app/assets/javascripts/stimulus_controllers.js"
+  ],
+  { stdio: "inherit" }
+)
+
+if (result.status !== 0) process.exit(result.status)
+console.log("FlatPack Stimulus bundle written to app/assets/javascripts/stimulus_controllers.js")
+```
+
+#### 3. Add an npm build script
+
+In `package.json`, add to the `scripts` section:
+
+```json
+{
+  "scripts": {
+    "build:stimulus": "node scripts/build_stimulus.js"
+  }
+}
+```
+
+#### 4. Run the build
+
+```bash
+npm run build:stimulus
+```
+
+This generates `app/assets/javascripts/stimulus_controllers.js` — a self-contained IIFE that boots Stimulus and registers all selected FlatPack controllers.
+
+#### 5. Include the bundle in your layout
+
+In your application layout (e.g., `app/views/layouts/application.html.erb`), add the script tag **before** your other application JavaScript:
+
+```erb
+<%# FlatPack Stimulus controllers — must load before scripts that depend on them %>
+<%= javascript_include_tag "stimulus_controllers", defer: true %>
+```
+
+**Important:** `stimulus_controllers.js` must be placed in `app/assets/javascripts/` (or another directory on the Propshaft/Sprockets asset path) so Rails can serve and fingerprint it.
+
+#### 6. Rebuild after FlatPack updates
+
+After running `bundle update flat_pack`, regenerate the bundle because the gem path (which includes a git hash) will have changed:
+
+```bash
+npm run build:stimulus
+```
+
+Add this to your CI / deploy pipeline to keep the bundle current automatically.
+
+**Sidebar localStorage key:** The `flat-pack--sidebar-layout` controller persists the sidebar open/closed state in localStorage. The key is controlled by the `data-flat-pack--sidebar-layout-storage-key-value` attribute on the controller element. The generated sidebar template defaults to `flat-pack-sidebar-layout`. Override it per layout if you need app-specific namespacing:
+
+```erb
+<div data-controller="flat-pack--sidebar-layout"
+     data-flat-pack--sidebar-layout-storage-key-value="my-app-sidebar">
+```
+
 ### 6. Verify Tailwind CSS Source Scanning
 
 Tailwind CSS 4 scans files via `@source` directives in your CSS file (no `tailwind.config.js` required).
@@ -431,6 +622,22 @@ Key points:
    ```
 
 3. Restart the Rails server
+
+### Sidebar / Interactive Components Not Working (Non-Importmap Apps)
+
+**Symptom:** The sidebar does not collapse or expand when the chevron button is clicked. Other interactive components (modals, popovers, tooltips, tabs) also appear inert. No JavaScript errors appear in the browser console.
+
+**Root cause:** The `flat-pack--sidebar-layout` Stimulus controller (and all other FlatPack Stimulus controllers) was never registered with the Stimulus application. The install generator only configures FlatPack for importmap-based Rails apps. Apps that use esbuild, Webpack, Vite, or a custom JS build pipeline bypass the importmap setup entirely, so the controllers are never loaded.
+
+**Fix:** Follow the steps in **Section 5.2** above to:
+
+1. Create `scripts/build_stimulus.js` — a Node script that dynamically resolves the FlatPack gem path via `bundle show flat_pack` and bundles the controllers with esbuild.
+2. Run `npm run build:stimulus` to generate `app/assets/javascripts/stimulus_controllers.js`.
+3. Include the bundle in your layout **before** other scripts using `<%= javascript_include_tag "stimulus_controllers", defer: true %>`.
+
+**Verify the fix:** Open the browser DevTools console. You should see no "Unknown custom element" warnings. Clicking the sidebar chevron should immediately collapse/expand the sidebar, and the state should persist across page reloads via localStorage.
+
+---
 
 ### JavaScript Not Working
 

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.3)
+    flat_pack (0.1.5)
       pagy (~> 9.0)
       rails (~> 8.0)
       tailwind_merge (~> 0.13)


### PR DESCRIPTION
…o 0.1.5

- Add Section 5.2 to installation.md: step-by-step bundling of all FlatPack Stimulus controllers for esbuild/Webpack/Vite apps
- scripts/build_stimulus.js: dynamically resolves gem path via bundle show, registers all 45 FlatPack controllers into a self-contained IIFE
- Add troubleshooting entry for sidebar/interactive components not working in non-importmap apps
- Bump version 0.1.4 -> 0.1.5 in version.rb and both Gemfile.lock files
- Update CHANGELOG