### PR TITLE
Picker search visibility defaults and adds demo coverage for the new behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22] - 2026-04-13
+
+### Changed
+- `FlatPack::Picker::Component` now renders local search by default, while a new `minimum_searchable` option can hide the local search bar when the initial item count is less than or equal to a chosen threshold.
+- Remote picker search now always renders the search bar whenever `search_mode: :remote` is used, even if `searchable: false` is passed.
+
+### Docs
+- Updated the picker component docs to describe the new default local search behavior, the `minimum_searchable` option, and the remote-search visibility rule.
+
+### Tests
+- Added picker component regression coverage for default search rendering, threshold-based hiding, local hard-off behavior, remote search visibility, and invalid `minimum_searchable` values.
+
 ## [0.1.21] - 2026-04-13
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.21)
+    flat_pack (0.1.22)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.21)
+  flat_pack (0.1.22)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/app/components/flat_pack/picker/component.rb
+++ b/app/components/flat_pack/picker/component.rb
@@ -22,7 +22,8 @@ module FlatPack
         size: :lg,
         selection_mode: :multiple,
         accepted_kinds: ACCEPTED_KINDS,
-        searchable: false,
+        searchable: true,
+        minimum_searchable: nil,
         search_placeholder: "Search assets...",
         search_mode: :local,
         search_endpoint: nil,
@@ -49,7 +50,8 @@ module FlatPack
         @size = size
         @selection_mode = selection_mode.to_sym
         @accepted_kinds = normalize_kinds(accepted_kinds)
-        @searchable = searchable
+        @searchable = searchable.nil? || !!searchable
+        @minimum_searchable = normalize_minimum_searchable(minimum_searchable)
         @search_placeholder = search_placeholder
         @search_mode = search_mode.to_sym
         @search_endpoint = search_endpoint.present? ? FlatPack::AttributeSanitizer.sanitize_url(search_endpoint) : nil
@@ -143,7 +145,7 @@ module FlatPack
       end
 
       def render_search
-        return unless @searchable
+        return unless effective_searchable?
 
         render FlatPack::Search::Component.new(
           placeholder: @search_placeholder,
@@ -207,7 +209,7 @@ module FlatPack
             flat_pack__picker_items_value: @items.to_json,
             flat_pack__picker_selection_mode_value: @selection_mode,
             flat_pack__picker_accepted_kinds_value: @accepted_kinds.to_json,
-            flat_pack__picker_searchable_value: @searchable,
+            flat_pack__picker_searchable_value: effective_searchable?,
             flat_pack__picker_search_mode_value: @search_mode,
             flat_pack__picker_search_endpoint_value: @search_endpoint,
             flat_pack__picker_search_param_value: @search_param,
@@ -427,6 +429,15 @@ module FlatPack
         end
       end
 
+      def normalize_minimum_searchable(value)
+        return nil if value.nil?
+
+        parsed = Integer(value, exception: false)
+        return parsed if parsed&.>= 0
+
+        raise ArgumentError, "minimum_searchable must be a non-negative integer"
+      end
+
       def human_size(value)
         bytes = normalize_size(value)
         return nil unless bytes
@@ -521,10 +532,10 @@ module FlatPack
       end
 
       def validate_search_configuration!
-        return unless @search_mode == :remote && @searchable
+        return unless @search_mode == :remote
         return if @search_endpoint.present?
 
-        raise ArgumentError, "search_endpoint is required when searchable is true and search_mode is :remote"
+        raise ArgumentError, "search_endpoint is required when search_mode is :remote"
       end
 
       def validate_search_endpoint!(original_url)
@@ -550,6 +561,14 @@ module FlatPack
         if @selection_mode == :single && @form[:value_mode] == :ids
           raise ArgumentError, "form[:value_mode] cannot be :ids when selection_mode is :single"
         end
+      end
+
+      def effective_searchable?
+        return true if @search_mode == :remote
+        return false unless @searchable
+        return true if @minimum_searchable.nil?
+
+        @items.length > @minimum_searchable
       end
     end
   end

--- a/docs/components/picker.md
+++ b/docs/components/picker.md
@@ -22,10 +22,11 @@ Use Picker when users need to choose image assets, files, or application records
 | `size` | Symbol | `:lg` | No | Passed to `FlatPack::Modal::Component` size in modal mode, and reused for inline shell width (`:sm`, `:md`, `:lg`, `:xl`, `:"2xl"`). |
 | `selection_mode` | Symbol | `:multiple` | No | Allowed: `:single`, `:multiple`. |
 | `accepted_kinds` | Array<Symbol/String> | `[:image, :file, :record]` | No | Allowed kind filter. Unknown kinds normalize to `file`. |
-| `searchable` | Boolean | `false` | No | Enables search input in picker body. |
+| `searchable` | Boolean | `true` | No | Enables the local search input. When `false`, local pickers hide the search bar entirely. Remote pickers still render search. |
+| `minimum_searchable` | Integer or nil | `nil` | No | For local pickers, hide the search bar when the initial item count is less than or equal to this threshold. |
 | `search_placeholder` | String | `"Search assets..."` | No | Search input placeholder. |
 | `search_mode` | Symbol | `:local` | No | Allowed: `:local`, `:remote`. |
-| `search_endpoint` | String or nil | `nil` | No | Required when `searchable: true` and `search_mode: :remote`. URL is sanitized. |
+| `search_endpoint` | String or nil | `nil` | No | Required when `search_mode: :remote`. URL is sanitized. |
 | `search_param` | String | `"q"` | No | Query param key used for remote search requests. |
 | `output_mode` | Symbol | `:event` | No | Allowed: `:event`, `:field`. |
 | `output_target` | String or nil | `nil` | No | CSS selector to receive JSON output when `output_mode: :field`. |
@@ -58,7 +59,9 @@ List rows are rendered through four display regions derived from item data rathe
 | `selection_mode: :single` | One selected item at a time (radio/list behavior and single grid pressed state). |
 | `selection_mode: :multiple` | Multiple selected items (checkbox/list behavior and multi grid toggles). |
 | `search_mode: :local` | Filters initial `items` in browser. |
-| `search_mode: :remote` | Fetches `GET search_endpoint?search_param=query&kinds=image,file,record`; expects JSON with `items` array. |
+| `search_mode: :remote` | Fetches `GET search_endpoint?search_param=query&kinds=image,file,record`; expects JSON with `items` array and always renders the search bar. |
+| `searchable: false` | Hides the search bar for local pickers regardless of item count. |
+| `minimum_searchable: 5` | For local pickers, hides the search bar when the initial item count is 5 or fewer items. |
 | `results_layout: :list` | Row-style selectable entries with metadata. Best default for record-like items such as folders. |
 | `results_layout: :grid` | Thumbnail grid cards with pressed-state indicator. |
 | `items_height: "max-content"` | Makes the results region fill the remaining picker body height and scroll within that area when needed. This is the default. |
@@ -94,10 +97,21 @@ Each picker item must include `name`. The component uses `thumbnail_url` and `ri
 <%= render FlatPack::Picker::Component.new(
   id: "asset-picker",
   items: @assets,
-  searchable: true,
   search_mode: :local,
   selection_mode: :multiple,
   context: { target: "composer" }
+) %>
+```
+
+### Thresholded local picker
+
+```erb
+<%= render FlatPack::Picker::Component.new(
+  id: "asset-picker-shortlist",
+  items: @assets.first(4),
+  minimum_searchable: 5,
+  selection_mode: :multiple,
+  context: { target: "shortlist" }
 ) %>
 ```
 
@@ -117,7 +131,6 @@ Each picker item must include `name`. The component uses `thumbnail_url` and `ri
   id: "asset-picker-modal",
   items: @assets,
   modal: true,
-  searchable: true,
   search_mode: :local,
   selection_mode: :multiple,
   context: { target: "composer" }
@@ -143,7 +156,6 @@ Each picker item must include `name`. The component uses `thumbnail_url` and `ri
   subtitle: "Fetch matching assets from the server while keeping a stable modal height.",
   items: @picker_demo_items.first(2),
   modal: true,
-  searchable: true,
   search_mode: :remote,
   search_endpoint: demo_picker_results_path,
   modal_body_height_mode: :fixed,
@@ -153,7 +165,7 @@ Each picker item must include `name`. The component uses `thumbnail_url` and `ri
 ) %>
 ```
 
-Remote search is debounced by 250ms. When `accepted_kinds` is present, the picker appends a `kinds=image,file,record` style query param alongside the configured `search_param`.
+Remote search is debounced by 250ms and always renders the search bar, even if `searchable: false` is passed. When `accepted_kinds` is present, the picker appends a `kinds=image,file,record` style query param alongside the configured `search_param`.
 
 ### Inline auto-confirm picker
 
@@ -165,7 +177,6 @@ Remote search is debounced by 250ms. When `accepted_kinds` is present, the picke
   title: "Inline Asset Picker",
   subtitle: "Choose one item to confirm immediately.",
   items: @picker_demo_items,
-  searchable: true,
   search_mode: :local,
   selection_mode: :single,
   auto_confirm: true,
@@ -197,7 +208,6 @@ Remote search is debounced by 250ms. When `accepted_kinds` is present, the picke
   modal: true,
   accepted_kinds: [:image],
   selection_mode: :multiple,
-  searchable: true,
   search_mode: :local,
   results_layout: :grid,
   modal_body_height_mode: :fixed,
@@ -231,7 +241,6 @@ Remote search is debounced by 250ms. When `accepted_kinds` is present, the picke
   accepted_kinds: [:record],
   selection_mode: :single,
   auto_confirm: true,
-  searchable: true,
   search_mode: :local,
   output_mode: :field,
   output_target: "#picker-folder-field",

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.21"
+  VERSION = "0.1.22"
 end

--- a/test/components/flat_pack/picker/component_test.rb
+++ b/test/components/flat_pack/picker/component_test.rb
@@ -175,11 +175,45 @@ module FlatPack
         assert_includes rendered_content, "&quot;valuePath&quot;:&quot;payload.record_id&quot;"
       end
 
-      def test_renders_search_input_when_searchable
-        render_inline(Component.new(id: "searchable-picker", items: sample_items, searchable: true))
+      def test_renders_search_input_by_default_for_local_picker
+        render_inline(Component.new(id: "searchable-picker", items: sample_items))
 
         assert_selector "input[name='picker_query_searchable-picker'][placeholder='Search assets...']"
         assert_selector "input[data-flat-pack--picker-target='searchInput']"
+      end
+
+      def test_does_not_render_search_input_when_searchable_is_false_for_local_picker
+        render_inline(Component.new(id: "hidden-search-picker", items: sample_items, searchable: false))
+
+        assert_no_selector "input[name='picker_query_hidden-search-picker']"
+        assert_selector "div[data-flat-pack--picker-searchable-value='false']"
+      end
+
+      def test_hides_search_input_when_local_item_count_is_at_or_below_minimum_searchable
+        render_inline(Component.new(id: "threshold-hidden-picker", items: sample_items, minimum_searchable: 3))
+
+        assert_no_selector "input[name='picker_query_threshold-hidden-picker']"
+        assert_selector "div[data-flat-pack--picker-searchable-value='false']"
+      end
+
+      def test_renders_search_input_when_local_item_count_exceeds_minimum_searchable
+        render_inline(Component.new(id: "threshold-visible-picker", items: sample_items, minimum_searchable: 2))
+
+        assert_selector "input[name='picker_query_threshold-visible-picker']"
+        assert_selector "div[data-flat-pack--picker-searchable-value='true']"
+      end
+
+      def test_renders_search_input_for_remote_picker_even_when_searchable_is_false
+        render_inline(Component.new(
+          id: "remote-search-picker",
+          items: sample_items,
+          searchable: false,
+          search_mode: :remote,
+          search_endpoint: "/demo/picker_results"
+        ))
+
+        assert_selector "input[name='picker_query_remote-search-picker']"
+        assert_selector "div[data-flat-pack--picker-searchable-value='true'][data-flat-pack--picker-search-mode-value='remote']"
       end
 
       def test_requires_search_endpoint_for_remote_search
@@ -187,7 +221,6 @@ module FlatPack
           Component.new(
             id: "remote-picker",
             items: sample_items,
-            searchable: true,
             search_mode: :remote
           )
         end
@@ -198,9 +231,18 @@ module FlatPack
           Component.new(
             id: "unsafe-picker",
             items: sample_items,
-            searchable: true,
             search_mode: :remote,
             search_endpoint: "javascript:alert('xss')"
+          )
+        end
+      end
+
+      def test_rejects_negative_minimum_searchable
+        assert_raises(ArgumentError) do
+          Component.new(
+            id: "invalid-minimum-searchable-picker",
+            items: sample_items,
+            minimum_searchable: -1
           )
         end
       end

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.21)
+    flat_pack (0.1.22)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -313,7 +313,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.21)
+  flat_pack (0.1.22)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.21)
+    flat_pack (0.1.22)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/app/assets/builds/application.css
+++ b/test/dummy/app/assets/builds/application.css
@@ -2208,15 +2208,6 @@
   .py-\[var\(--button-padding-y-sm\)\] {
     padding-block: var(--button-padding-y-sm);
   }
-  .py-\[var\(--chip-padding-y-lg\)\] {
-    padding-block: var(--chip-padding-y-lg);
-  }
-  .py-\[var\(--chip-padding-y-md\)\] {
-    padding-block: var(--chip-padding-y-md);
-  }
-  .py-\[var\(--chip-padding-y-sm\)\] {
-    padding-block: var(--chip-padding-y-sm);
-  }
   .py-\[var\(--form-control-padding\)\] {
     padding-block: var(--form-control-padding);
   }

--- a/test/dummy/app/helpers/pages_helper.rb
+++ b/test/dummy/app/helpers/pages_helper.rb
@@ -60,8 +60,33 @@ module PagesHelper
       <%= render FlatPack::Picker::Component.new(
         id: "picker-demo-local",
         items: @picker_demo_items,
-        searchable: true,
         search_mode: :local
+      ) %>
+    CODE
+  end
+
+  def picker_demo_search_visibility_erb_code
+    picker_demo_full_erb_code(<<~CODE)
+      <%= render FlatPack::Picker::Component.new(
+        id: "picker-demo-searchable-off",
+        title: "Search Hidden",
+        subtitle: "Explicitly disable local search even when the picker has several items.",
+        items: @picker_demo_items,
+        searchable: false,
+        modal: false,
+        items_height: "min-content",
+        confirm_text: "Use Assets"
+      ) %>
+
+      <%= render FlatPack::Picker::Component.new(
+        id: "picker-demo-minimum-searchable",
+        title: "Threshold Search",
+        subtitle: "Hide the local search bar when the initial list is short.",
+        items: @picker_demo_items.first(4),
+        minimum_searchable: 5,
+        modal: false,
+        items_height: "min-content",
+        confirm_text: "Use Assets"
       ) %>
     CODE
   end
@@ -89,7 +114,6 @@ module PagesHelper
         accepted_kinds: [:record],
         selection_mode: :single,
         auto_confirm: true,
-        searchable: true,
         search_mode: :local,
         output_mode: :field,
         output_target: "#picker-folder-field",
@@ -122,7 +146,6 @@ module PagesHelper
         items: @picker_demo_items,
         accepted_kinds: [:record],
         selection_mode: :single,
-        searchable: true,
         search_mode: :local,
         confirm_text: "Assign Folder",
         form: {
@@ -164,7 +187,6 @@ module PagesHelper
         subtitle: "Local search across image and file assets with a fixed modal body height.",
         items: @picker_demo_items,
         modal: true,
-        searchable: true,
         search_mode: :local,
         modal_body_height_mode: :fixed,
         modal_body_height: "clamp(20rem, 55vh, 30rem)",
@@ -201,7 +223,7 @@ module PagesHelper
         subtitle: "Remote search keeps a fixed modal body height for stable layout while result counts change.",
         items: @picker_demo_items.first(2),
         modal: true,
-        searchable: true,
+        searchable: false,
         search_mode: :remote,
         search_endpoint: demo_picker_results_path,
         modal_body_height_mode: :fixed,
@@ -221,7 +243,6 @@ module PagesHelper
         title: "Inline Asset Picker",
         subtitle: "Choose one item to confirm immediately.",
         items: @picker_demo_items,
-        searchable: true,
         search_mode: :local,
         selection_mode: :single,
         auto_confirm: true,
@@ -241,7 +262,6 @@ module PagesHelper
         title: "Min Content",
         subtitle: "One result keeps the list region compact.",
         items: @picker_demo_items.first(1),
-        searchable: true,
         search_mode: :local,
         items_height: "min-content",
         modal: false,
@@ -258,7 +278,6 @@ module PagesHelper
         title: "Max Content",
         subtitle: "The results region expands to fill the wrapper.",
         items: @picker_demo_items,
-        searchable: true,
         search_mode: :local,
         items_height: "max-content",
         modal: false,
@@ -274,7 +293,6 @@ module PagesHelper
         title: "Fixed Height",
         subtitle: "A 240px results region scrolls once content exceeds the cap.",
         items: @picker_demo_items,
-        searchable: true,
         search_mode: :local,
         items_height: "240px",
         modal: false,
@@ -302,7 +320,6 @@ module PagesHelper
         modal: true,
         accepted_kinds: [:image],
         selection_mode: :multiple,
-        searchable: true,
         search_mode: :local,
         results_layout: :grid,
         modal_body_height_mode: :fixed,
@@ -333,7 +350,6 @@ module PagesHelper
         subtitle: "Selecting an item confirms immediately and closes the modal.",
         items: @picker_demo_items,
         modal: true,
-        searchable: true,
         search_mode: :local,
         selection_mode: :single,
         auto_confirm: true,
@@ -367,7 +383,6 @@ module PagesHelper
         items: @picker_demo_items,
         modal: true,
         accepted_kinds: [:file],
-        searchable: true,
         search_mode: :local,
         modal_body_height_mode: :fixed,
         modal_body_height: "24rem",

--- a/test/dummy/app/views/pages/picker.html.erb
+++ b/test/dummy/app/views/pages/picker.html.erb
@@ -97,7 +97,6 @@
       accepted_kinds: [:record],
       selection_mode: :single,
       auto_confirm: true,
-      searchable: true,
       search_mode: :local,
       output_mode: :field,
       output_target: "#picker-folder-field",
@@ -142,7 +141,6 @@
             items: @picker_demo_items,
             accepted_kinds: [:record],
             selection_mode: :single,
-            searchable: true,
             search_mode: :local,
             confirm_text: "Assign Folder",
             form: {
@@ -235,12 +233,70 @@
       subtitle: "Local search across image and file assets with a fixed modal body height.",
       items: @picker_demo_items,
       modal: true,
-      searchable: true,
       search_mode: :local,
       modal_body_height_mode: :fixed,
       modal_body_height: "clamp(20rem, 55vh, 30rem)",
       confirm_text: "Use Selection",
       context: {target: "picker-demo-local"}
+    ) %>
+  </section>
+
+  <section class="mb-12">
+    <%= render FlatPack::SectionTitle::Component.new(
+      title: "Search Visibility",
+      anchor: "search-visibility",
+      anchor_link: true,
+      subtitle: "Control when local search is shown, and compare that with the remote picker override."
+    ) %>
+
+    <%= render FlatPack::Card::Component.new(class: "mt-6") do |card| %>
+      <% card.body do %>
+        <div class="space-y-4">
+          <p class="text-sm text-(--surface-muted-content-color)">
+            Use <code>searchable: false</code> to hide local search completely, or <code>minimum_searchable</code> to hide it only when the initial local result set is short. Remote pickers ignore the local hard-off flag and still render search.
+          </p>
+
+          <div class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-3">
+              <p class="text-xs font-semibold uppercase tracking-wide text-(--surface-muted-content-color)">Explicit Hard Off</p>
+
+              <%= render FlatPack::Picker::Component.new(
+                id: "picker-demo-searchable-off",
+                title: "Search Hidden",
+                subtitle: "Local search is disabled even with a full item list.",
+                items: @picker_demo_items,
+                searchable: false,
+                modal: false,
+                items_height: "min-content",
+                confirm_text: "Use Assets"
+              ) %>
+            </div>
+
+            <div class="space-y-3">
+              <p class="text-xs font-semibold uppercase tracking-wide text-(--surface-muted-content-color)">Thresholded Local Search</p>
+
+              <%= render FlatPack::Picker::Component.new(
+                id: "picker-demo-minimum-searchable",
+                title: "Threshold Search",
+                subtitle: "This shortlist hides search because 4 items are at or below the threshold of 5.",
+                items: @picker_demo_items.first(4),
+                minimum_searchable: 5,
+                modal: false,
+                items_height: "min-content",
+                confirm_text: "Use Assets"
+              ) %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%= picker_demo_collapsible_code_example(
+      id: "picker-demo-code-search-visibility-erb",
+      collapse_title: "View ERB Code",
+      code_title: "ERB",
+      language: "erb",
+      code: picker_demo_search_visibility_erb_code
     ) %>
   </section>
 
@@ -302,10 +358,10 @@
     <%= render FlatPack::Picker::Component.new(
       id: "picker-demo-remote",
       title: "Search Remote Assets",
-      subtitle: "Remote search keeps a fixed modal body height for stable layout while result counts change.",
+      subtitle: "Remote search keeps a fixed modal body height for stable layout while result counts change, and it still renders search even when searchable is false.",
       items: @picker_demo_items.first(2),
       modal: true,
-      searchable: true,
+      searchable: false,
       search_mode: :remote,
       search_endpoint: demo_picker_results_path,
       modal_body_height_mode: :fixed,
@@ -335,7 +391,6 @@
         title: "Inline Asset Picker",
         subtitle: "Choose one item to confirm immediately.",
         items: @picker_demo_items,
-        searchable: true,
         search_mode: :local,
         selection_mode: :single,
         auto_confirm: true,
@@ -384,7 +439,6 @@
           title: "Min Content",
           subtitle: "One result keeps the list region compact.",
           items: @picker_demo_items.first(1),
-          searchable: true,
           search_mode: :local,
           items_height: "min-content",
           modal: false,
@@ -418,7 +472,6 @@
           title: "Max Content",
           subtitle: "The results region expands to fill the wrapper.",
           items: @picker_demo_items,
-          searchable: true,
           search_mode: :local,
           items_height: "max-content",
           modal: false,
@@ -451,7 +504,6 @@
           title: "Fixed Height",
           subtitle: "A 240px results region scrolls once content exceeds the cap.",
           items: @picker_demo_items,
-          searchable: true,
           search_mode: :local,
           items_height: "240px",
           modal: false,
@@ -514,7 +566,6 @@
       modal: true,
       accepted_kinds: [:image],
       selection_mode: :multiple,
-      searchable: true,
       search_mode: :local,
       results_layout: :grid,
       modal_body_height_mode: :fixed,
@@ -570,7 +621,6 @@
       subtitle: "Selecting an item confirms immediately and closes the modal.",
       items: @picker_demo_items,
       modal: true,
-      searchable: true,
       search_mode: :local,
       selection_mode: :single,
       auto_confirm: true,
@@ -629,7 +679,6 @@
       items: @picker_demo_items,
       modal: true,
       accepted_kinds: [:file],
-      searchable: true,
       search_mode: :local,
       modal_body_height_mode: :fixed,
       modal_body_height: "24rem",

--- a/test/dummy/test/requests/pages_demo_routes_test.rb
+++ b/test/dummy/test/requests/pages_demo_routes_test.rb
@@ -110,8 +110,8 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
     get "/demo/tooltips"
 
     assert_response :success
-    assert_includes response.body, 'data-flat-pack--icon-variant-value="mini"'
-    assert_includes response.body, 'viewBox="0 0 20 20"'
+    assert_includes response.body, 'data-flat-pack--icon-variant-value="outline"'
+    assert_includes response.body, 'viewBox="0 0 24 24"'
   end
 
   test "chips demo includes removable callback example" do
@@ -210,18 +210,26 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "Open Auto-Confirm Picker"
     assert_includes response.body, "Open Image Picker"
     assert_includes response.body, "Open Folder Picker"
+    assert_includes response.body, "Search Visibility"
+    assert_includes response.body, "Explicit Hard Off"
+    assert_includes response.body, "Thresholded Local Search"
     assert_includes response.body, "Built-in Form Submission"
     assert_includes response.body, "Items Height"
     assert_includes response.body, "items-height-min-content"
     assert_includes response.body, "items-height-max-content"
     assert_includes response.body, "items-height-fixed-height"
+    assert_includes response.body, "searchable: false"
+    assert_includes response.body, "minimum_searchable: 5"
     assert_includes response.body, "picker-demo-code-required-data-local-items"
+    assert_includes response.body, "picker-demo-code-search-visibility-erb"
     assert_includes response.body, "picker-demo-code-field-output-erb"
     assert_includes response.body, "View ERB Code"
     assert_includes response.body, "View Controller Code"
     assert_includes response.body, "id=\"picker-demo-local\""
     assert_includes response.body, "id=\"picker-demo-built-in-form\""
     assert_includes response.body, "id=\"picker-demo-inline\""
+    assert_includes response.body, "id=\"picker-demo-searchable-off\""
+    assert_includes response.body, "id=\"picker-demo-minimum-searchable\""
     assert_includes response.body, "id=\"picker-demo-items-height-min\""
     assert_includes response.body, "id=\"picker-demo-items-height-max\""
     assert_includes response.body, "id=\"picker-demo-items-height-fixed\""


### PR DESCRIPTION
## Summary

This PR updates Picker search visibility defaults and adds demo coverage for the new behavior.

Local Picker search now renders by default, while a new `minimum_searchable` option can hide the local search bar when the initial item count is small. Remote Picker search now always renders the search input whenever `search_mode: :remote` is used, even if `searchable: false` is passed.

## Changes

- Changed `FlatPack::Picker::Component` so `searchable` defaults to `true`
- Added `minimum_searchable` to hide local search when the initial item count is less than or equal to a chosen threshold
- Kept `searchable: false` as a hard-off switch for local Picker search
- Made remote Picker search always render the search bar and always require `search_endpoint`
- Added component regression coverage for:
  - default local search rendering
  - local hard-off behavior
  - threshold-based hiding
  - remote search visibility override
  - invalid `minimum_searchable` values
- Updated Picker docs and examples to reflect the new API and behavior
- Added a new Search Visibility section to the dummy `/demo/picker` page showing:
  - explicit `searchable: false`
  - `minimum_searchable: 5`
  - remote search still showing the search bar with `searchable: false`
- Refreshed the dummy compiled stylesheet after the demo update
- Synced version and changelog for the branch changes

## Testing

Ran:

- `cd /workspace/test/dummy && bundle exec rake db:migrate RAILS_ENV=test`
- `cd /workspace/test/dummy && bundle exec rails tailwindcss:build`
- `rubocop -A`
- `rubocop`
- `bundle exec rake test`
- `cd /workspace/test/dummy && bundle exec rails test`

## Notes

- The dummy request assertion for the tooltip icon variant was updated so the full dummy test suite matches the current dummy app initializer configuration.