### PR TITLE
Fix admin demo pagination and enhance page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-04-24
+
+### Fixed
+- Changed breadcrumb back-link resolution to derive from the previous linked breadcrumb level instead of the HTTP referer, preventing breadcrumb back buttons from looping between sibling pages, while preserving explicit override and fallback behavior.
+
+### Tests
+- Added breadcrumb regression coverage for derived back-link targets, explicit `back_href` overrides, and fallback behavior when no earlier linked breadcrumb item exists.
+
+### Docs
+- Updated breadcrumb component documentation and dummy demo copy to describe hierarchy-based back-link behavior and the new `back_href` option.
+
 ## [0.1.27] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-04-24
+
+### Changed
+- Added an `actions` slot to `FlatPack::PageTitle::Component`, rendering action content directly below the subtitle when present and directly below the title when no subtitle is provided.
+- Updated the admin dashboard and page-title demo pages to use the new `PageTitle` actions slot for inline page-level controls.
+
+### Tests
+- Added focused component coverage for `PageTitle` actions placement with and without a subtitle, and kept the admin demo request coverage asserting the rendered action button.
+
+### Docs
+- Updated the Page Title component documentation to describe the new `actions` slot, its placement behavior, and block-based usage examples.
+
 ## [0.1.29] - 2026-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.29] - 2026-04-24
+
+### Changed
+- Added the standard FlatPack pagination component to the dummy admin dashboard user-management table and expanded the demo dataset so the page consistently shows a multi-page admin listing.
+
+### Tests
+- Added dummy request coverage to ensure the admin demo responds successfully and continues rendering pagination controls.
+
 ## [0.1.28] - 2026-04-24
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.28)
+    flat_pack (0.1.29)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.28)
+  flat_pack (0.1.29)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.29)
+    flat_pack (0.1.30)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.29)
+  flat_pack (0.1.30)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.27)
+    flat_pack (0.1.28)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.27)
+  flat_pack (0.1.28)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/app/components/flat_pack/breadcrumb/component.rb
+++ b/app/components/flat_pack/breadcrumb/component.rb
@@ -25,6 +25,7 @@ module FlatPack
         show_back: false,
         back_text: "Back",
         back_icon: "chevron-left",
+        back_href: nil,
         back_fallback_url: "/",
         show_home: false,
         home_url: "/",
@@ -41,6 +42,7 @@ module FlatPack
         @show_back = show_back
         @back_text = back_text
         @back_icon = back_icon
+        @back_href_override = back_href
         @back_fallback_url = back_fallback_url
         @show_home = show_home
         @home_url = home_url
@@ -87,16 +89,23 @@ module FlatPack
       end
 
       def build_items_list
+        breadcrumb_items = build_breadcrumb_items
         items_list = []
 
         # Add back item if requested
         if @show_back
           items_list << item(
             text: @back_text,
-            href: back_href,
+            href: resolved_back_href(breadcrumb_items),
             icon: @back_icon
           )
         end
+
+        items_list + breadcrumb_items
+      end
+
+      def build_breadcrumb_items
+        items_list = []
 
         # Add home item if requested
         if @show_home
@@ -110,8 +119,12 @@ module FlatPack
         items_list + items
       end
 
-      def back_href
-        request&.referer || @back_fallback_url
+      def resolved_back_href(breadcrumb_items)
+        @back_href_override || previous_breadcrumb_href(breadcrumb_items) || @back_fallback_url
+      end
+
+      def previous_breadcrumb_href(breadcrumb_items)
+        breadcrumb_items[0...-1].reverse_each.find(&:href)&.href
       end
 
       def maybe_collapse_items(items_list)

--- a/app/components/flat_pack/breadcrumb/item/component.rb
+++ b/app/components/flat_pack/breadcrumb/item/component.rb
@@ -4,6 +4,8 @@ module FlatPack
   module Breadcrumb
     module Item
       class Component < ViewComponent::Base
+        attr_reader :href
+
         def initialize(
           text:,
           href: nil,
@@ -19,7 +21,7 @@ module FlatPack
         end
 
         def current?
-          @href.nil?
+          href.nil?
         end
 
         def call
@@ -41,7 +43,7 @@ module FlatPack
         end
 
         def render_link_item
-          link_to(@href,
+          link_to(href,
             {
               class: "flex items-center text-[var(--breadcrumb-link-color)] hover:text-[var(--breadcrumb-link-hover-color)] transition-colors"
             }.merge(@system_arguments)) do

--- a/app/components/flat_pack/page_title/component.rb
+++ b/app/components/flat_pack/page_title/component.rb
@@ -5,6 +5,12 @@ module FlatPack
     class Component < FlatPack::BaseComponent
       VARIANTS = %i[h1 h2 h3 h4 h5 h6].freeze
 
+      renders_one :actions
+
+      alias_method :actions_slot, :actions
+
+      undef_method :with_actions, :with_actions_content
+
       def initialize(
         title:,
         subtitle: nil,
@@ -22,6 +28,12 @@ module FlatPack
 
       def call
         content_tag(:div, **container_attributes) { render_header_content }
+      end
+
+      def actions(*args, **kwargs, &block)
+        return actions_slot if args.empty? && kwargs.empty? && !block_given?
+
+        set_slot(:actions, nil, *args, **kwargs, &block)
       end
 
       private
@@ -46,7 +58,8 @@ module FlatPack
         content_tag(:div, class: "flex-1 min-w-0") do
           safe_join([
             render_title,
-            render_subtitle
+            render_subtitle,
+            render_actions
           ].compact)
         end
       end
@@ -68,6 +81,12 @@ module FlatPack
         return nil unless @subtitle
 
         content_tag(:p, @subtitle, class: "mt-2 text-lg text-[var(--surface-muted-content-color)]")
+      end
+
+      def render_actions
+        return nil unless actions?
+
+        content_tag(:div, actions, class: "page-title-actions mt-4 flex flex-wrap items-center gap-3")
       end
 
       def validate_title!

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-04-16",
+  "updated_at": "2026-04-24",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.27"
+    "version": "0.1.30"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -17,10 +17,11 @@ Use Breadcrumb on nested pages where users need orientation and quick navigation
 |---|---|---|---|---|
 | `separator` | Symbol | `:chevron` | no | Separator style: `:chevron`, `:slash`, `:arrow`, `:dot`, `:custom`; invalid values raise `ArgumentError`. |
 | `separator_icon` | String | `nil` | no | Icon name used only when `separator: :custom`. |
-| `show_back` | Boolean | `false` | no | Prepends a back item using `request.referer` fallback behavior. |
+| `show_back` | Boolean | `false` | no | Prepends a back item that defaults to the previous linked breadcrumb level. |
 | `back_text` | String | `"Back"` | no | Back item text. |
 | `back_icon` | String | `"chevron-left"` | no | Back item icon name. |
-| `back_fallback_url` | String | `"/"` | no | URL used when referer is unavailable. |
+| `back_href` | String | `nil` | no | Explicit back target that overrides derived breadcrumb behavior. |
+| `back_fallback_url` | String | `"/"` | no | URL used when no previous linked breadcrumb level exists. |
 | `show_home` | Boolean | `false` | no | Prepends a home item before declared items. |
 | `home_url` | String | `"/"` | no | Home item URL. |
 | `home_text` | String | `"Home"` | no | Home item label text. |
@@ -65,6 +66,8 @@ Use Breadcrumb on nested pages where users need orientation and quick navigation
   <% breadcrumb.item(text: "Profile") %>
 <% end %>
 ```
+
+When `show_back: true` is enabled, the back item resolves to the previous linked breadcrumb item by default. Use `back_href:` to force a specific destination, and `back_fallback_url:` when the trail has no earlier linked level.
 
 ## Accessibility
 - Wrapper uses semantic `<nav aria-label="Breadcrumb">` with ordered list items.

--- a/docs/components/page-title.md
+++ b/docs/components/page-title.md
@@ -18,7 +18,9 @@ Use Page Title for page-level headings when you do not want the bordered visual 
 | `**system_arguments` | Hash | `{}` | no | HTML attributes for outer wrapper. |
 
 ## Slots
-None.
+| name | type | description |
+|---|---|---|
+| `actions` | Block | Optional action content rendered directly below the subtitle, or directly below the title when no subtitle is present. |
 
 ## Variants
 - Heading level variants: `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6`
@@ -29,8 +31,16 @@ None.
   title: "Team settings",
   subtitle: "Control membership and permissions",
   variant: :h2
-) %>
+) do |page_title| %>
+  <% page_title.actions do %>
+    <%= render FlatPack::Button::Component.new(text: "Invite member", style: :secondary, size: :sm) %>
+  <% end %>
+<% end %>
 ```
+
+## Behavior
+- `actions` renders immediately below the subtitle when `subtitle` is present.
+- `actions` renders immediately below the title when `subtitle` is omitted.
 
 ## Accessibility
 - Uses semantic heading tags via `variant` (`h1`-`h6`).

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.28"
+  VERSION = "0.1.29"
 end

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.29"
+  VERSION = "0.1.30"
 end

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.27"
+  VERSION = "0.1.28"
 end

--- a/test/components/flat_pack/breadcrumb_component_test.rb
+++ b/test/components/flat_pack/breadcrumb_component_test.rb
@@ -176,7 +176,7 @@ module FlatPack
         assert_text "Home"
       end
 
-      def test_renders_back_item_when_enabled
+      def test_renders_back_item_when_enabled_with_fallback
         render_inline(Component.new(show_back: true, back_fallback_url: "/previous")) do |breadcrumb|
           breadcrumb.item(text: "Current")
         end
@@ -184,6 +184,43 @@ module FlatPack
         assert_selector "a[href='/previous']", text: "Back"
         assert_selector "nav ol li:first-child a[href='/previous']", text: "Back"
         assert_selector "svg[data-flat-pack--icon-name-value='chevron-left']"
+      end
+
+      def test_renders_back_item_from_previous_breadcrumb_link
+        render_inline(Component.new(show_back: true, back_fallback_url: "/previous")) do |breadcrumb|
+          breadcrumb.item(text: "Home", href: "/")
+          breadcrumb.item(text: "Dashboard", href: "/dashboard")
+          breadcrumb.item(text: "Post", href: "/posts/1")
+          breadcrumb.item(text: "Edit")
+        end
+
+        assert_selector "nav ol li:first-child a[href='/posts/1']", text: "Back"
+        refute_selector "a[href='/previous']", text: "Back"
+      end
+
+      def test_ignores_referer_to_avoid_back_link_loop
+        component = Component.new(show_back: true, back_fallback_url: "/previous")
+        component.define_singleton_method(:request) do
+          Struct.new(:referer).new("/posts/1/edit")
+        end
+
+        render_inline(component) do |breadcrumb|
+          breadcrumb.item(text: "Home", href: "/")
+          breadcrumb.item(text: "Dashboard", href: "/dashboard")
+          breadcrumb.item(text: "Post")
+        end
+
+        assert_selector "nav ol li:first-child a[href='/dashboard']", text: "Back"
+        refute_selector "a[href='/posts/1/edit']", text: "Back"
+      end
+
+      def test_back_href_override_takes_precedence
+        render_inline(Component.new(show_back: true, back_href: "/custom-back", back_fallback_url: "/previous")) do |breadcrumb|
+          breadcrumb.item(text: "Home", href: "/")
+          breadcrumb.item(text: "Current")
+        end
+
+        assert_selector "nav ol li:first-child a[href='/custom-back']", text: "Back"
       end
 
       def test_renders_back_before_home_when_both_enabled
@@ -200,7 +237,7 @@ module FlatPack
           breadcrumb.item(text: "Current")
         end
 
-        assert_selector "a[href='/previous']", text: "Back"
+        assert_selector "a[href='/']", text: "Back"
         assert_selector "a[href='/']", text: "Home"
         assert_no_selector "nav[aria-label='Breadcrumb'] li:first-child + li[aria-hidden='true']"
         assert_selector "nav[aria-label='Breadcrumb'] li[aria-hidden='true']"
@@ -212,6 +249,14 @@ module FlatPack
         end
 
         assert_selector "a[href='/prev']", text: "Go Back"
+      end
+
+      def test_falls_back_when_no_previous_breadcrumb_link_exists
+        render_inline(Component.new(show_back: true, back_fallback_url: "/prev")) do |breadcrumb|
+          breadcrumb.item(text: "Current")
+        end
+
+        assert_selector "a[href='/prev']", text: "Back"
       end
 
       # Collapsed Items Tests

--- a/test/components/flat_pack/page_title/component_test.rb
+++ b/test/components/flat_pack/page_title/component_test.rb
@@ -37,6 +37,26 @@ module FlatPack
         assert_selector "p", text: "Welcome back"
       end
 
+      def test_renders_actions_slot_below_subtitle
+        render_inline(Component.new(title: "Dashboard", subtitle: "Welcome back")) do |component|
+          component.actions do
+            "Filter"
+          end
+        end
+
+        assert_selector "p + div.page-title-actions", text: "Filter"
+      end
+
+      def test_renders_actions_slot_below_title_when_subtitle_missing
+        render_inline(Component.new(title: "Dashboard")) do |component|
+          component.actions do
+            "Filter"
+          end
+        end
+
+        assert_selector "h1 + div.page-title-actions", text: "Filter"
+      end
+
       def test_raises_error_for_invalid_variant
         error = assert_raises(ArgumentError) do
           render_inline(Component.new(title: "Dashboard", variant: :heading))

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.27)
+    flat_pack (0.1.30)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -313,7 +313,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.27)
+  flat_pack (0.1.30)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.29)
+    flat_pack (0.1.30)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.27)
+    flat_pack (0.1.29)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -1711,7 +1711,19 @@ class PagesController < ApplicationController
   def page_cache_asset_version
     asset_paths = CACHED_LAYOUT_STYLESHEETS.map { |logical_path| helpers.asset_path(logical_path) }
     asset_paths << current_importmap_digest
+    asset_paths << page_template_cache_version
     Digest::SHA256.hexdigest(asset_paths.join("|"))[0, 12]
+  end
+
+  def page_template_cache_version
+    template_files = Dir[Rails.root.join("app/views/layouts/**/*")].concat(Dir[Rails.root.join("app/views/pages/**/*")]).sort
+    template_versions = template_files.filter_map do |path|
+      next unless File.file?(path)
+
+      "#{path}:#{File.mtime(path).to_f}"
+    end
+
+    Digest::SHA256.hexdigest(template_versions.join("|"))[0, 12]
   end
 
   def current_importmap_digest

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -150,19 +150,36 @@ class PagesController < ApplicationController
       {label: "Open Tickets", value: "128", change: "-4.3%", trend: :down, icon: :alert}
     ]
 
-    @admin_users = Array.new(12) do |i|
+    admin_user_templates = [
+      {name: "Alice Johnson", email: "alice@example.com", role: "Admin", status: "Active"},
+      {name: "Bob Smith", email: "bob@example.com", role: "Editor", status: "Active"},
+      {name: "Carol White", email: "carol@example.com", role: "Viewer", status: "Active"},
+      {name: "David Lee", email: "david@example.com", role: "Admin", status: "Active"},
+      {name: "Eva Martinez", email: "eva@example.com", role: "Editor", status: "Active"},
+      {name: "Frank Brown", email: "frank@example.com", role: "Viewer", status: "Inactive"},
+      {name: "Grace Kim", email: "grace@example.com", role: "Admin", status: "Active"},
+      {name: "Henry Davis", email: "henry@example.com", role: "Editor", status: "Active"},
+      {name: "Iris Chen", email: "iris@example.com", role: "Viewer", status: "Active"},
+      {name: "James Wilson", email: "james@example.com", role: "Admin", status: "Pending"},
+      {name: "Karen Taylor", email: "karen@example.com", role: "Editor", status: "Active"},
+      {name: "Liam Moore", email: "liam@example.com", role: "Viewer", status: "Active"}
+    ]
+
+    @admin_users = Array.new(24) do |i|
+      template = admin_user_templates[i % admin_user_templates.length]
+      email_local, email_domain = template[:email].split("@", 2)
+
       OpenStruct.new(
         id: i + 1,
-        name: ["Alice Johnson", "Bob Smith", "Carol White", "David Lee", "Eva Martinez",
-          "Frank Brown", "Grace Kim", "Henry Davis", "Iris Chen", "James Wilson",
-          "Karen Taylor", "Liam Moore"][i],
-        email: ["alice", "bob", "carol", "david", "eva", "frank", "grace",
-          "henry", "iris", "james", "karen", "liam"][i] + "@example.com",
-        role: %w[Admin Editor Viewer Admin Editor Viewer Admin Editor Viewer Admin Editor Viewer][i],
-        status: %w[Active Active Active Active Active Inactive Active Active Active Pending Active Active][i],
+        name: template[:name],
+        email: "#{email_local}+#{i + 1}@#{email_domain}",
+        role: template[:role],
+        status: template[:status],
         joined_at: (i * 15 + 5).days.ago.strftime("%b %d, %Y")
       )
     end
+
+    @admin_pagy, @admin_users = pagy_array(@admin_users, items: 10)
   end
 
   def inputs

--- a/test/dummy/app/views/pages/_component_method_variables_table.html.erb
+++ b/test/dummy/app/views/pages/_component_method_variables_table.html.erb
@@ -51,6 +51,7 @@
         { variable: "show_back", accepts: "true, false", example: "show_back: true" },
         { variable: "back_text", accepts: "String", example: "back_text: \"Go Back\"" },
         { variable: "back_icon", accepts: "String", example: "back_icon: \"chevron-left\"" },
+        { variable: "back_href", accepts: "String or nil", example: "back_href: \"/dashboard\"" },
         { variable: "back_fallback_url", accepts: "String", example: "back_fallback_url: \"/dashboard\"" },
         { variable: "show_home", accepts: "true, false", example: "show_home: true" },
         { variable: "home_url", accepts: "String", example: "home_url: \"/dashboard\"" },

--- a/test/dummy/app/views/pages/admin.html.erb
+++ b/test/dummy/app/views/pages/admin.html.erb
@@ -10,7 +10,11 @@
 <%= render FlatPack::PageTitle::Component.new(
   title: "Admin Dashboard",
   subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."
-) %>
+) do |page_title| %>
+  <% page_title.actions do %>
+    <%= render FlatPack::Button::Component.new(text: "Filter", style: :secondary, size: :sm) %>
+  <% end %>
+<% end %>
 
 <%# Stats and chart cards — 3 columns, horizontally scrollable on mobile %>
 <div class="mt-6 mb-8">

--- a/test/dummy/app/views/pages/admin.html.erb
+++ b/test/dummy/app/views/pages/admin.html.erb
@@ -83,5 +83,7 @@
       }) %>
       <% table.column(title: "Joined", html: ->(u) { "<span class=\"text-sm text-[var(--surface-muted-content-color)]\">#{u.joined_at}</span>".html_safe }) %>
     <% end %>
+
+    <%= render FlatPack::Pagination::Component.new(pagy: @admin_pagy, class: "mt-4") %>
   </div>
 </section>

--- a/test/dummy/app/views/pages/breadcrumbs.html.erb
+++ b/test/dummy/app/views/pages/breadcrumbs.html.erb
@@ -126,7 +126,7 @@
   <section class="mb-12">
     <%= render FlatPack::SectionTitle::Component.new(title: "With Back Item", anchor_link: true, subtitle: "Examples for With Back Item.") %>
     <p class="text-sm text-[var(--surface-muted-content-color)] mb-3">
-      The back link is prepended as the first breadcrumb item and resolves to the previous page when available.
+      The back link is prepended as the first breadcrumb item and resolves to the previous linked breadcrumb level by default.
     </p>
     <div class="mb-4">
       <%= render FlatPack::Breadcrumb::Component.new(
@@ -146,6 +146,7 @@
           &lt;% breadcrumb.item(text: "Settings", href: "/settings") %&gt;
           &lt;% breadcrumb.item(text: "Profile") %&gt;
         &lt;% end %&gt;
+        &lt;!-- Back resolves to /settings here, and falls back to /demo only when no earlier linked item exists. --&gt;
       CODE
     ) %>
   </section>

--- a/test/dummy/app/views/pages/page_header.html.erb
+++ b/test/dummy/app/views/pages/page_header.html.erb
@@ -103,6 +103,36 @@
   ) %>
 </section>
 
+<!-- Page Title with Actions -->
+<section class="mb-12">
+  <%= render FlatPack::SectionTitle::Component.new(title: "Page Title with Actions", anchor_link: true, subtitle: "Examples for Page Title with Actions.") %>
+  <%= render FlatPack::PageTitle::Component.new(
+    title: "Admin Dashboard",
+    subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."
+  ) do |page_title| %>
+    <% page_title.actions do %>
+      <%= render FlatPack::Button::Component.new(text: "Filter", style: :secondary, size: :sm) %>
+      <%= render FlatPack::Button::Component.new(text: "Export", style: :ghost, size: :sm) %>
+    <% end %>
+  <% end %>
+
+  <%= render FlatPack::CodeBlock::Component.new(
+    title: "ERB",
+    language: "erb",
+    code: <<~CODE
+      #{erb_output_open} render FlatPack::PageTitle::Component.new(
+        title: "Admin Dashboard",
+        subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."
+      ) do |page_title| #{erb_tag_close}
+        #{erb_output_open} page_title.actions do #{erb_tag_close}
+          #{erb_output_open} render FlatPack::Button::Component.new(text: "Filter", style: :secondary, size: :sm) #{erb_tag_close}
+          #{erb_output_open} render FlatPack::Button::Component.new(text: "Export", style: :ghost, size: :sm) #{erb_tag_close}
+        #{erb_output_open} end #{erb_tag_close}
+      #{erb_output_open} end #{erb_tag_close}
+    CODE
+  ) %>
+</section>
+
 <!-- Page Header with Longer Subtitle -->
 <section class="mb-12">
   <%= render FlatPack::SectionTitle::Component.new(title: "Page Header with Longer Subtitle", anchor_link: true, subtitle: "Examples for Page Header with Longer Subtitle.") %>

--- a/test/dummy/app/views/pages/tables_basic.html.erb
+++ b/test/dummy/app/views/pages/tables_basic.html.erb
@@ -12,6 +12,14 @@
     <% table.column(title: "Name", html: ->(user) { user.name }) %>
     <% table.column(title: "Email", html: ->(user) { user.email }) %>
     <% table.column(title: "Category", html: ->(user) { user.category.to_s.titleize }) %>
+    <% table.column(title: "Actions", html: ->(user) {
+      dropdown = FlatPack::Button::Dropdown::Component.new(text: "Actions", style: :ghost)
+      dropdown.menu_item(text: "View #{user.name}", icon: "eye", href: "#")
+      dropdown.menu_item(text: "Edit #{user.name}", icon: "pencil", href: "#")
+      dropdown.menu_divider
+      dropdown.menu_item(text: "Delete", icon: "trash", destructive: true, href: "#")
+      render dropdown
+    }) %>
   <% end %>
 
   <%= render FlatPack::CodeBlock::Component.new(
@@ -21,6 +29,14 @@
         &lt;% table.column(title: &quot;Name&quot;, html: -&gt;(user) { user.name }) %&gt;
         &lt;% table.column(title: &quot;Email&quot;, html: -&gt;(user) { user.email }) %&gt;
         &lt;% table.column(title: &quot;Category&quot;, html: -&gt;(user) { user.category.to_s.titleize }) %&gt;
+        &lt;% table.column(title: &quot;Actions&quot;, html: -&gt;(user) {
+          dropdown = FlatPack::Button::Dropdown::Component.new(text: &quot;Actions&quot;, style: :ghost)
+          dropdown.menu_item(text: &quot;View #{user.name}&quot;, icon: &quot;eye&quot;, href: &quot;#&quot;)
+          dropdown.menu_item(text: &quot;Edit #{user.name}&quot;, icon: &quot;pencil&quot;, href: &quot;#&quot;)
+          dropdown.menu_divider
+          dropdown.menu_item(text: &quot;Delete&quot;, icon: &quot;trash&quot;, destructive: true, href: &quot;#&quot;)
+          render dropdown
+        }) %&gt;
       &lt;% end %&gt;
     CODE
     language: "erb",

--- a/test/dummy/test/controllers/pages_controller_private_test.rb
+++ b/test/dummy/test/controllers/pages_controller_private_test.rb
@@ -60,6 +60,31 @@ class PagesControllerPrivateTest < ActiveSupport::TestCase
     assert_includes new_key, request.path
   end
 
+  test "page_cache_key changes when page template version changes" do
+    controller = PagesController.new
+    request = OpenStruct.new(path: "/demo/tables/basic")
+    controller.define_singleton_method(:request) { request }
+
+    helpers = Object.new
+    define_asset_path_helper(helpers, {
+      "application.css" => "/assets/application-stable.css",
+      "flat_pack/variables.css" => "/assets/flat_pack/variables-stable.css",
+      "flat_pack/rich_text.css" => "/assets/flat_pack/rich_text-stable.css",
+      "flat_pack/content_editor.css" => "/assets/flat_pack/content_editor-stable.css"
+    })
+
+    controller.define_singleton_method(:helpers) { helpers }
+    controller.define_singleton_method(:current_importmap_digest) { "importmap-stable" }
+    controller.define_singleton_method(:page_template_cache_version) { "templates-old" }
+    old_key = controller.send(:page_cache_key)
+
+    controller.define_singleton_method(:page_template_cache_version) { "templates-new" }
+    new_key = controller.send(:page_cache_key)
+
+    refute_equal old_key, new_key
+    assert_includes new_key, request.path
+  end
+
   private
 
   def define_asset_path_helper(helper, asset_paths)

--- a/test/dummy/test/requests/pages_demo_routes_test.rb
+++ b/test/dummy/test/requests/pages_demo_routes_test.rb
@@ -95,6 +95,7 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
     get "/demo/admin"
 
     assert_response :success
+    assert_includes response.body, "Filter"
     assert_includes response.body, 'aria-label="Pagination"'
     assert_includes response.body, "?page=2"
   end

--- a/test/dummy/test/requests/pages_demo_routes_test.rb
+++ b/test/dummy/test/requests/pages_demo_routes_test.rb
@@ -53,6 +53,7 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
     /demo/grid
     /demo/grid/movable_cards
     /demo/pagination
+    /demo/admin
     /demo/charts
     /demo/code_blocks
     /demo/avatars
@@ -88,6 +89,14 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
       get path
       assert_response :success, "Expected #{path} to return success"
     end
+  end
+
+  test "admin demo renders pagination" do
+    get "/demo/admin"
+
+    assert_response :success
+    assert_includes response.body, 'aria-label="Pagination"'
+    assert_includes response.body, "?page=2"
   end
 
   test "chat demo keeps composer visible in full-height panel" do

--- a/test/dummy/test/requests/pages_tables_demo_test.rb
+++ b/test/dummy/test/requests/pages_tables_demo_test.rb
@@ -15,5 +15,7 @@ class PagesTablesDemoTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_includes response.body, "Basic Table Demos"
+    assert_includes response.body, "Actions"
+    assert_includes response.body, "View User 1"
   end
 end


### PR DESCRIPTION
Improve the admin demo by adding pagination and updating the page title component to include an actions slot for inline controls. Fix breadcrumb link resolution and address caching issues in the basic table actions demo.