### PR TITLE
Add DigitalOcean deployment support for dummy app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.32] - 2026-04-27
+
+### Added
+- Added DigitalOcean App Platform deployment support for the Rails dummy app, including a checked-in app spec with separate web and Sidekiq worker services.
+
+### Changed
+- Switched the Rails 8 dummy app to PostgreSQL in production, added a production Puma config, and enabled production defaults for static assets, SSL, and Sidekiq-backed Active Job.
+
+### Docs
+- Added a dedicated DigitalOcean deployment guide for the dummy app and linked it from the main documentation surfaces.
+
 ## [0.1.30] - 2026-04-24
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.30)
+    flat_pack (0.1.32)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.30)
+  flat_pack (0.1.32)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ rails generate flat_pack:layout --type=sidebar --side=right --layout_name=admin
 
 See the [Installation Guide](docs/installation.md) for detailed setup instructions.
 
+If you want to deploy the dummy Rails app in `test/dummy`, use the [DigitalOcean deployment guide](docs/deployment_digitalocean.md). That guide is for the demo app only, not a requirement for FlatPack host applications.
+
 ## AI Entry Points
 
 For AI-assisted installation and usage, start with the gem-shipped contract and verification surfaces instead of inferring setup from prose alone:

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ bin/rake flat_pack:verify_install
 
 ### Getting Started
 - [Installation Guide](installation.md)
+- [DigitalOcean Deployment for the Dummy App](deployment_digitalocean.md)
 - [AI Entry Point](ai/README.md)
 - [AI Install Contract](ai/install_contract.json)
 - [Quick Start](#quick-start)

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-04-24",
+  "updated_at": "2026-04-27",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.30"
+    "version": "0.1.32"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/deployment_digitalocean.md
+++ b/docs/deployment_digitalocean.md
@@ -1,0 +1,68 @@
+# DigitalOcean Deployment for the Dummy App
+
+This guide deploys the Rails demo app in `test/dummy` to DigitalOcean App Platform. It does not turn the FlatPack gem itself into a hosted service.
+
+## What is already wired in this repository
+
+- `test/dummy/config/puma.rb` starts the web process on the port App Platform provides.
+- `test/dummy/config/database.yml` expects `DATABASE_URL` in production so the dummy app can use managed PostgreSQL.
+- `test/dummy/config/environments/production.rb` serves precompiled assets, enables SSL, and uses Sidekiq for Active Job.
+- `test/dummy/.do/app.yaml` defines a web service plus a Sidekiq worker for App Platform.
+
+## Recommended DigitalOcean resources
+
+- One App Platform app
+- One managed PostgreSQL database
+- One managed Redis database
+- One custom domain if you want a stable public URL
+
+## Required application secrets
+
+Set these in App Platform before the first successful deploy:
+
+- `SECRET_KEY_BASE`: required
+- `DATABASE_URL`: required, usually from the managed PostgreSQL cluster
+- `REDIS_URL`: required, used by Sidekiq
+- `RAILS_SERVE_STATIC_FILES=1`: required so Rails serves Propshaft assets
+- `RAILS_FORCE_SSL=true`: recommended
+- `ACTIVE_STORAGE_SERVICE=local`: default for the demo app unless you add Spaces-backed storage
+- `RAILS_MASTER_KEY`: optional unless you rely on encrypted credentials
+
+## App Platform setup
+
+1. Create a managed PostgreSQL cluster.
+2. Create a managed Redis cluster.
+3. Create an App Platform app from this GitHub repository.
+4. Point the app at `test/dummy/.do/app.yaml`, or mirror that file in the App Platform UI.
+5. Keep the service source directory set to `test/dummy` so Bundler can still resolve `gem "flat_pack", path: "../.."`.
+6. Replace the placeholder secret values from the app spec with your real `SECRET_KEY_BASE`, `DATABASE_URL`, and `REDIS_URL` values.
+7. Deploy the web service and worker.
+8. After the first deploy, run `bundle exec rails db:prepare` from the App Platform console or a one-off job.
+9. Verify `https://your-app.example.com/up` returns healthy before checking demo pages.
+
+## Commands used by the checked-in app spec
+
+Web build command:
+
+```bash
+bundle install && bundle exec rails assets:precompile
+```
+
+Web run command:
+
+```bash
+bundle exec puma -C config/puma.rb
+```
+
+Worker run command:
+
+```bash
+bundle exec sidekiq -e production -C config/sidekiq.yml
+```
+
+## Production notes
+
+- The dummy app keeps Active Storage on local disk by default. App Platform filesystems are ephemeral, so uploads do not persist across rebuilds unless you add object storage.
+- If you want persistent uploads, add a production storage service backed by DigitalOcean Spaces and switch `ACTIVE_STORAGE_SERVICE` to that service name.
+- The checked-in app spec disables `deploy_on_push` by default. Enable it if you want every push to `main` to roll out automatically.
+- If App Platform build detection ever fails to resolve the path-based FlatPack gem, keep the source rooted at the full repository and avoid exporting only the dummy subdirectory.

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.30"
+  VERSION = "0.1.32"
 end

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.30)
+    flat_pack (0.1.32)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -313,7 +313,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.30)
+  flat_pack (0.1.32)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/.do/app.yaml
+++ b/test/dummy/.do/app.yaml
@@ -1,0 +1,86 @@
+name: flatpack-dummy
+region: nyc
+
+services:
+  - name: dummy-web
+    github:
+      repo: bowerbird-app/flatpack
+      branch: main
+      deploy_on_push: false
+    source_dir: test/dummy
+    environment_slug: ruby
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    http_port: 8080
+    build_command: bundle install && bundle exec rails assets:precompile
+    run_command: bundle exec puma -C config/puma.rb
+    health_check:
+      http_path: /up
+    envs:
+      - key: RAILS_ENV
+        scope: RUN_AND_BUILD_TIME
+        value: production
+      - key: RAILS_SERVE_STATIC_FILES
+        scope: RUN_AND_BUILD_TIME
+        value: "1"
+      - key: RAILS_FORCE_SSL
+        scope: RUN_TIME
+        value: "true"
+      - key: ACTIVE_STORAGE_SERVICE
+        scope: RUN_TIME
+        value: local
+      - key: SECRET_KEY_BASE
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: REDIS_URL
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: RAILS_MASTER_KEY
+        scope: RUN_TIME
+        type: SECRET
+        value: OPTIONAL_IF_USING_ENCRYPTED_CREDENTIALS
+
+workers:
+  - name: dummy-worker
+    github:
+      repo: bowerbird-app/flatpack
+      branch: main
+      deploy_on_push: false
+    source_dir: test/dummy
+    environment_slug: ruby
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    build_command: bundle install
+    run_command: bundle exec sidekiq -e production -C config/sidekiq.yml
+    envs:
+      - key: RAILS_ENV
+        scope: RUN_AND_BUILD_TIME
+        value: production
+      - key: RAILS_FORCE_SSL
+        scope: RUN_TIME
+        value: "true"
+      - key: ACTIVE_STORAGE_SERVICE
+        scope: RUN_TIME
+        value: local
+      - key: SECRET_KEY_BASE
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: REDIS_URL
+        scope: RUN_TIME
+        type: SECRET
+        value: REPLACE_ME
+      - key: RAILS_MASTER_KEY
+        scope: RUN_TIME
+        type: SECRET
+        value: OPTIONAL_IF_USING_ENCRYPTED_CREDENTIALS

--- a/test/dummy/Gemfile
+++ b/test/dummy/Gemfile
@@ -9,7 +9,6 @@ gem "flat_pack", path: "../.."
 gem "rails", ">= 8.1.2.1", "< 8.2"
 gem "puma", ">= 5.0"
 gem "propshaft", "~> 1.0"
-gem "sqlite3", ">= 2.1"
 gem "sidekiq"
 gem "redis"
 
@@ -24,7 +23,12 @@ gem "view_component"
 gem "devise"
 
 group :development, :test do
+  gem "sqlite3", ">= 2.1"
   gem "debug", platforms: %i[mri mingw x64_mingw]
+end
+
+group :production do
+  gem "pg", "~> 1.5"
 end
 
 group :development do

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.30)
+    flat_pack (0.1.32)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -176,6 +176,13 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (9.4.0)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -331,6 +338,7 @@ DEPENDENCIES
   devise
   flat_pack!
   importmap-rails
+  pg (~> 1.5)
   propshaft (~> 1.0)
   puma (>= 5.0)
   rails (>= 8.1.2.1, < 8.2)

--- a/test/dummy/README.md
+++ b/test/dummy/README.md
@@ -157,6 +157,17 @@ cd ../..
 bundle exec rake test
 ```
 
+## Deployment
+
+The dummy app can be deployed to DigitalOcean App Platform with the checked-in example spec at `test/dummy/.do/app.yaml`.
+
+- Use managed PostgreSQL for `DATABASE_URL`
+- Use managed Redis for `REDIS_URL`
+- Set `SECRET_KEY_BASE` in App Platform secrets
+- Run `bundle exec rails db:prepare` after the first deploy
+
+See [../../docs/deployment_digitalocean.md](../../docs/deployment_digitalocean.md) for the full setup flow.
+
 ## Directory Structure
 
 ```

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -18,5 +18,7 @@ test:
   database: storage/test.sqlite3
 
 production:
-  <<: *default
-  database: storage/production.sqlite3
+  adapter: postgresql
+  url: <%= ENV.fetch("DATABASE_URL") %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -19,6 +19,6 @@ test:
 
 production:
   adapter: postgresql
-  url: <%= ENV.fetch("DATABASE_URL") %>
+  url: <%= ENV["DATABASE_URL"] %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -23,16 +23,17 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  # config.active_storage.service = :local
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE", "local").to_sym
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = ENV.fetch("RAILS_FORCE_SSL", "true") == "true"
+  config.assume_ssl = config.force_ssl
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
@@ -54,8 +55,8 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "dummy_production"
+  config.active_job.queue_adapter = :sidekiq
+  config.active_job.queue_name_prefix = "dummy_production"
 
   # Disable caching for Action Mailer templates even if Action Controller
   # caching is enabled.

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
+
+threads min_threads_count, max_threads_count
+
+port ENV.fetch("PORT", 3000)
+environment ENV.fetch("RAILS_ENV", "development")
+pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+workers ENV.fetch("WEB_CONCURRENCY", 2) if ENV["RAILS_ENV"] == "production"
+
+preload_app! if ENV["RAILS_ENV"] == "production"
+
+plugin :tmp_restart


### PR DESCRIPTION
Introduce support for deploying the dummy Rails app to DigitalOcean App Platform. Update configurations for PostgreSQL and Puma, and provide a dedicated deployment guide. Increment version to 0.1.32 to reflect these changes.