### PR TITLE
Bump gem version to 0.1.37 and add tree component demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a new dummy Text Content demo page under `/demo/text/content` to showcase long-form editorial and marketing copy with primary-theme color accents.
+- Added a new `FlatPack::Tree::Component` plus `/demo/tree` examples for VS Code-style folder explorers and nested list navigation.
 
 ### Changed
 - Added `rich_text` and `rich_text_options` pass-through support to the comments composer and inline input wrappers so reply and comment fields can opt into the shared TipTap-backed `TextArea` editor while remaining plain text by default.
@@ -16,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Restored the dummy app importmap's missing `@tiptap/*` package pins so rich-text comment and textarea demos can actually boot the `flat-pack--tiptap` controller in the browser.
 - Explicitly registered the dummy app's `flat-pack--tiptap` Stimulus controller so rich-text demos do not rely solely on nested lazy controller discovery at first paint.
+- Added component file versions to the dummy app's full-page cache key so component-only demo updates, including the new Tree markup, no longer serve stale cached HTML until the cache expires.
+
+## [0.1.36] - 2026-05-05
+
+### Added
+- Added a new `FlatPack::Tree::Component` for rendering expandable folder trees and hierarchical lists with a nested node DSL.
+- Added dummy app route, sidebar entry, search index coverage, and documentation for the new Tree component.
 
 ## [0.1.35] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.37] - 2026-05-05
+
 ### Added
 - Added a new dummy Text Content demo page under `/demo/text/content` to showcase long-form editorial and marketing copy with primary-theme color accents.
 - Added a new `FlatPack::Tree::Component` plus `/demo/tree` examples for VS Code-style folder explorers and nested list navigation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.35)
+    flat_pack (0.1.36)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.35)
+  flat_pack (0.1.36)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.36)
+    flat_pack (0.1.37)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.36)
+  flat_pack (0.1.37)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Separators: `:chevron`, `:slash`, `:arrow`, `:dot`, `:custom`
 ### Data Display
 - **Table** - Data tables with configurable columns and optional drag-and-drop row reordering
 - **List** - Structured list with composable items, avatars, and actions
+- **Tree** - Nested hierarchical tree for folder explorers, file structures, and expandable lists
 - **Timeline** - Vertical event timeline with icons and timestamps
 - **Chart** - ApexCharts-based visualizations with optional card framing
 - **Progress** - Horizontal progress bar with optional label

--- a/app/components/flat_pack/tree/component.rb
+++ b/app/components/flat_pack/tree/component.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+module FlatPack
+  module Tree
+    class Component < FlatPack::BaseComponent
+      Node = Struct.new(
+        :label,
+        :href,
+        :icon,
+        :expanded,
+        :active,
+        :meta,
+        :children,
+        :system_arguments,
+        keyword_init: true
+      )
+
+      class Builder
+        attr_reader :nodes
+
+        def initialize(component)
+          @component = component
+          @nodes = []
+        end
+
+        def node(label:, href: nil, icon: nil, expanded: false, active: false, meta: nil, **system_arguments, &block)
+          @nodes << @component.send(
+            :build_node,
+            label: label,
+            href: href,
+            icon: icon,
+            expanded: expanded,
+            active: active,
+            meta: meta,
+            system_arguments: system_arguments,
+            &block
+          )
+        end
+      end
+
+      def initialize(compact: false, guides: true, **system_arguments)
+        super(**system_arguments)
+        @compact = compact
+        @guides = guides
+        @nodes = []
+      end
+
+      def node(label:, href: nil, icon: nil, expanded: false, active: false, meta: nil, **system_arguments, &block)
+        @nodes << build_node(
+          label: label,
+          href: href,
+          icon: icon,
+          expanded: expanded,
+          active: active,
+          meta: meta,
+          system_arguments: system_arguments,
+          &block
+        )
+      end
+
+      def call
+        content
+
+        content_tag(:div, **tree_attributes) do
+          safe_join(@nodes.map.with_index { |tree_node, index| render_node(tree_node, level: 1, index: index) })
+        end
+      end
+
+      private
+
+      def build_node(label:, href:, icon:, expanded:, active:, meta:, system_arguments:, &block)
+        child_builder = Builder.new(self)
+        block&.call(child_builder)
+
+        sanitized_href = sanitize_url(href)
+        validate_href!(href, sanitized_href)
+
+        Node.new(
+          label: label,
+          href: sanitized_href,
+          icon: icon || default_icon(child_builder.nodes.any?),
+          expanded: expanded,
+          active: active,
+          meta: meta,
+          children: child_builder.nodes,
+          system_arguments: sanitize_args(system_arguments)
+        )
+      end
+
+      def render_node(tree_node, level:, index:)
+        return render_leaf_node(tree_node, level: level, index: index) if tree_node.children.empty?
+
+        content_tag(:details, open: tree_node.expanded, class: "group space-y-0.5") do
+          safe_join([
+            content_tag(:summary, render_branch_row(tree_node, level: level), **summary_attributes(tree_node, level: level)),
+            content_tag(:div, safe_join(tree_node.children.map.with_index { |child, child_index| render_node(child, level: level + 1, index: child_index) }), **children_attributes)
+          ])
+        end
+      end
+
+      def render_branch_row(tree_node, level:)
+        safe_join([
+          render_active_indicator(tree_node),
+          content_tag(:span, render_chevron_icon, class: "flex h-4 w-4 items-center justify-center text-[var(--surface-muted-content-color)] transition-transform group-open:rotate-90"),
+          render_node_icon(tree_node),
+          content_tag(:span, tree_node.label, class: branch_label_classes(level)),
+          render_meta(tree_node)
+        ].compact)
+      end
+
+      def render_leaf_node(tree_node, level:, index:)
+        row = render_leaf_row(tree_node, level: level)
+
+        content_tag(:div, **leaf_wrapper_attributes(tree_node, level: level, index: index)) do
+          if tree_node.href.present?
+            link_to(tree_node.href, class: "flex min-w-0 flex-1 items-center gap-1.5", aria: {current: ("page" if tree_node.active)}) { row }
+          else
+            row
+          end
+        end
+      end
+
+      def render_leaf_row(tree_node, level:)
+        safe_join([
+          render_active_indicator(tree_node),
+          content_tag(:span, nil, class: "block h-4 w-4 flex-none"),
+          render_node_icon(tree_node),
+          content_tag(:span, tree_node.label, class: leaf_label_classes(level)),
+          render_meta(tree_node)
+        ].compact)
+      end
+
+      def render_active_indicator(tree_node)
+        return unless tree_node.active
+
+        content_tag(:span, nil, class: "absolute inset-y-0 left-0 w-0.5 rounded-full bg-[var(--color-primary)]")
+      end
+
+      def render_chevron_icon
+        render FlatPack::Shared::IconComponent.new(name: "chevron-right", size: :sm)
+      end
+
+      def render_node_icon(tree_node)
+        return unless tree_node.icon.present?
+
+        content_tag(:span, class: "flex h-4 w-4 flex-none items-center justify-center text-[var(--surface-muted-content-color)]") do
+          render FlatPack::Shared::IconComponent.new(name: tree_node.icon, size: :sm)
+        end
+      end
+
+      def render_meta(tree_node)
+        return if tree_node.meta.blank?
+
+        content_tag(:span, tree_node.meta, class: "ml-auto truncate text-xs text-[var(--surface-muted-content-color)]")
+      end
+
+      def tree_attributes
+        merge_attributes(
+          class: tree_classes,
+          role: "tree"
+        )
+      end
+
+      def tree_classes
+        classes(
+          "w-full text-sm text-[var(--surface-content-color)] select-none",
+          ("space-y-0.5" unless @compact)
+        )
+      end
+
+      def summary_attributes(tree_node, level:)
+        merge_node_attributes(
+          tree_node,
+          class: row_classes(tree_node),
+          role: "treeitem",
+          tabindex: 0,
+          aria: {
+            expanded: tree_node.expanded,
+            selected: tree_node.active,
+            level: level
+          }
+        )
+      end
+
+      def children_attributes
+        {
+          class: children_classes,
+          role: "group"
+        }
+      end
+
+      def children_classes
+        classes(
+          "ml-3.5 mt-0.5 pl-2 space-y-0.5",
+          ("border-l border-[var(--surface-border-color)]" if @guides)
+        )
+      end
+
+      def leaf_wrapper_attributes(tree_node, level:, index:)
+        merge_node_attributes(
+          tree_node,
+          class: row_classes(tree_node),
+          role: "treeitem",
+          tabindex: 0,
+          aria: {
+            selected: tree_node.active,
+            level: level,
+            posinset: index + 1
+          }
+        )
+      end
+
+      def row_classes(tree_node)
+        classes(
+          "group relative flex items-center gap-1.5 overflow-hidden rounded-[var(--radius-sm)] px-2 text-left transition-colors outline-none",
+          row_padding_classes,
+          "hover:bg-[var(--surface-subtle-background-color)] focus-visible:ring-2 focus-visible:ring-[var(--button-focus-ring-color)] focus-visible:ring-inset",
+          ("bg-[var(--surface-subtle-background-color)]" if tree_node.active),
+          tree_node.system_arguments[:class]
+        )
+      end
+
+      def row_padding_classes
+        @compact ? "py-1" : "py-1.5"
+      end
+
+      def branch_label_classes(level)
+        classes(
+          "min-w-0 truncate",
+          ("font-medium" if level <= 2)
+        )
+      end
+
+      def leaf_label_classes(_level)
+        classes("min-w-0 truncate")
+      end
+
+      def merge_node_attributes(tree_node, **additional_attrs)
+        node_attributes = tree_node.system_arguments.dup
+        node_class = node_attributes.delete(:class)
+        node_data = node_attributes.delete(:data) || {}
+        node_aria = node_attributes.delete(:aria) || {}
+
+        {
+          class: TailwindMerge::Merger.new.merge([additional_attrs.delete(:class), node_class].compact.join(" ")),
+          data: node_data.merge(additional_attrs.delete(:data) || {}),
+          aria: node_aria.merge(additional_attrs.delete(:aria) || {})
+        }.merge(node_attributes).merge(additional_attrs).compact
+      end
+
+      def default_icon(branch)
+        branch ? :folder : "document-text"
+      end
+
+      def sanitize_url(url)
+        return nil if url.nil?
+
+        FlatPack::AttributeSanitizer.sanitize_url(url)
+      end
+
+      def validate_href!(original_url, sanitized_url)
+        return unless original_url.present?
+        return if sanitized_url.present?
+
+        raise ArgumentError, "Unsafe URL detected. Only http, https, mailto, tel protocols and relative URLs are allowed."
+      end
+    end
+  end
+end

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-05-04",
+  "updated_at": "2026-05-05",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.35"
+    "version": "0.1.37"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -63,6 +63,7 @@ sortable_tables_examples | FlatPack::Table::Component | docs/components/sortable
 table | FlatPack::Table::Component | docs/components/table.md
 tabs | FlatPack::Tabs::Component | docs/components/tabs.md
 timeline | FlatPack::Timeline::Component | docs/components/timeline.md
+tree | FlatPack::Tree::Component | docs/components/tree.md
 toast | FlatPack::Toast::Component | docs/components/toast.md
 toasts | FlatPack::Toasts::Region::Component | docs/components/toasts.md
 tooltip | FlatPack::Tooltip::Component | docs/components/tooltip.md

--- a/docs/components/manifest.yml
+++ b/docs/components/manifest.yml
@@ -361,6 +361,12 @@ components:
     primary_class: FlatPack::Table::Component
     status: documented
 
+  - key: tree
+    title: Tree
+    doc: docs/components/tree.md
+    primary_class: FlatPack::Tree::Component
+    status: documented
+
   - key: tabs
     title: Tabs
     doc: docs/components/tabs.md

--- a/docs/components/tree.md
+++ b/docs/components/tree.md
@@ -1,0 +1,65 @@
+# Tree
+
+## Purpose
+Render expandable hierarchical trees for folder explorers, nested navigation, and structured parent-child content.
+
+## When to use
+Use Tree when users need to scan and expand nested relationships such as file systems, documentation sidebars, or grouped settings sections.
+
+## Class
+- Primary: `FlatPack::Tree::Component`
+
+## Props
+`FlatPack::Tree::Component`:
+
+| name | type | default | required | description |
+|---|---|---|---|---|
+| `compact` | Boolean | `false` | no | Uses tighter vertical row spacing for dense explorer-style trees. |
+| `guides` | Boolean | `true` | no | Shows or hides the vertical guide lines between nested groups. |
+| `**system_arguments` | Hash | `{}` | no | HTML attributes for the tree wrapper (`role="tree"`). |
+
+`tree.node(...)` builder arguments:
+
+| name | type | default | required | description |
+|---|---|---|---|---|
+| `label` | String | `nil` | yes | Visible text label for the node. |
+| `href` | String | `nil` | no | Optional link URL for leaf nodes. Unsafe URLs raise `ArgumentError`. |
+| `icon` | Symbol/String | auto | no | Optional shared icon name. Defaults to folder for branches and document text for leaves. |
+| `expanded` | Boolean | `false` | no | Starts branch nodes open when true. Ignored for leaf nodes. |
+| `active` | Boolean | `false` | no | Applies the active row state and selection styling. |
+| `meta` | String | `nil` | no | Optional trailing helper text, count, or status label. |
+| `**system_arguments` | Hash | `{}` | no | Extra HTML attributes merged onto the rendered row. |
+
+## Slots
+- The component uses a nested builder DSL via `tree.node(...) do |node| ... end`.
+- Nest additional `node.node(...)` calls inside a parent block to create child groups.
+
+## Variants
+- Standard or dense layout via `compact`.
+- Guide lines on or off via `guides`.
+- Branch nodes with nested children or leaf nodes with optional links.
+
+## Example
+```erb
+<%= render FlatPack::Tree::Component.new(compact: true) do |tree| %>
+  <% tree.node(label: "src", expanded: true) do |src| %>
+    <% src.node(label: "components", expanded: true) do |components| %>
+      <% components.node(label: "Button.tsx") %>
+      <% components.node(label: "Card.tsx") %>
+    <% end %>
+
+    <% src.node(label: "App.js", active: true) %>
+  <% end %>
+
+  <% tree.node(label: "package.json") %>
+<% end %>
+```
+
+## Accessibility
+- The wrapper renders with `role="tree"`.
+- Branch and leaf rows render with `role="treeitem"` and selection state.
+- Nested containers render with `role="group"`.
+- Interactive links remain keyboard-focusable when `href` is provided.
+
+## Dependencies
+- FlatPack install generator setup (`rails generate flat_pack:install`).

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.35"
+  VERSION = "0.1.36"
 end

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.36"
+  VERSION = "0.1.37"
 end

--- a/test/components/flat_pack/tree_component_test.rb
+++ b/test/components/flat_pack/tree_component_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module FlatPack
+  module Tree
+    class ComponentTest < ViewComponent::TestCase
+      def test_renders_tree_with_nested_branches_and_leaves
+        render_inline(Component.new) do |tree|
+          tree.node(label: "src", expanded: true) do |src|
+            src.node(label: "components", expanded: true) do |components|
+              components.node(label: "Button.tsx")
+            end
+          end
+
+          tree.node(label: "package.json", active: true)
+        end
+
+        assert_selector "div[role='tree']"
+        assert_selector "summary[role='treeitem']", text: "src"
+        assert_selector "div[role='group']"
+        assert_selector "div[role='treeitem']", text: "Button.tsx"
+        assert_selector "div[role='treeitem'][aria-selected='true']", text: "package.json"
+      end
+
+      def test_renders_links_for_leaf_nodes
+        render_inline(Component.new) do |tree|
+          tree.node(label: "README.md", href: "/demo/tree")
+        end
+
+        assert_selector "a[href='/demo/tree']", text: "README.md"
+        assert_includes page.native.to_html, 'class="flex min-w-0 flex-1 items-center gap-1.5"'
+      end
+
+      def test_allows_custom_icon_and_meta
+        render_inline(Component.new) do |tree|
+          tree.node(label: "app", icon: "code-bracket-square", meta: "12 files")
+        end
+
+        assert_includes page.native.to_html, "code-bracket-square"
+        assert_text "12 files"
+      end
+
+      def test_raises_error_for_unsafe_href
+        assert_raises ArgumentError do
+          render_inline(Component.new) do |tree|
+            tree.node(label: "Bad", href: "javascript:alert('xss')")
+          end
+        end
+      end
+
+      def test_merges_custom_container_classes
+        render_inline(Component.new(class: "tree-shell"))
+
+        assert_selector "div.tree-shell[role='tree']"
+      end
+    end
+  end
+end

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.35)
+    flat_pack (0.1.37)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -313,7 +313,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.35)
+  flat_pack (0.1.37)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.app_platform.lock
+++ b/test/dummy/Gemfile.app_platform.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.32)
+    flat_pack (0.1.37)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -379,7 +379,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.32)
+  flat_pack (0.1.37)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.32)
+    flat_pack (0.1.37)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/app/assets/builds/application.css
+++ b/test/dummy/app/assets/builds/application.css
@@ -324,6 +324,9 @@
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
+  .top-1 {
+    top: calc(var(--spacing) * 1);
+  }
   .top-1\/2 {
     top: calc(1 / 2 * 100%);
   }
@@ -754,8 +757,14 @@
   .min-h-screen {
     min-height: 100vh;
   }
+  .w-0 {
+    width: calc(var(--spacing) * 0);
+  }
   .w-0\.5 {
     width: calc(var(--spacing) * 0.5);
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
   }
   .w-1\.5 {
     width: calc(var(--spacing) * 1.5);
@@ -925,6 +934,9 @@
   .flex-none {
     flex: none;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .flex-shrink-0 {
     flex-shrink: 0;
   }
@@ -941,6 +953,10 @@
     --tw-translate-x: -100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .translate-x-1 {
+    --tw-translate-x: calc(var(--spacing) * 1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .translate-x-1\/4 {
     --tw-translate-x: calc(1 / 4 * 100%);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -949,12 +965,20 @@
     --tw-translate-x: 100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .-translate-y-1 {
+    --tw-translate-y: calc(var(--spacing) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/4 {
     --tw-translate-y: calc(calc(1 / 4 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-y-0 {
+    --tw-translate-y: calc(var(--spacing) * 0);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .translate-y-0\.5 {
@@ -1134,6 +1158,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(var(--stack-gap-lg) * var(--tw-space-y-reverse));
       margin-block-end: calc(var(--stack-gap-lg) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-0 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-0\.5 {
@@ -2517,6 +2548,9 @@
   .text-pretty {
     text-wrap: pretty;
   }
+  .text-wrap {
+    text-wrap: wrap;
+  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -3087,6 +3121,9 @@
   .ring-\[var\(--color-ring\)\] {
     --tw-ring-color: var(--color-ring);
   }
+  .ring-black {
+    --tw-ring-color: var(--color-black);
+  }
   .ring-black\/20 {
     --tw-ring-color: color-mix(in srgb, #000 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3114,6 +3151,10 @@
   }
   .backdrop-blur-lg {
     --tw-backdrop-blur: blur(var(--blur-lg));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }

--- a/test/dummy/app/assets/builds/application.css
+++ b/test/dummy/app/assets/builds/application.css
@@ -537,6 +537,9 @@
   .ml-3 {
     margin-left: calc(var(--spacing) * 3);
   }
+  .ml-3\.5 {
+    margin-left: calc(var(--spacing) * 3.5);
+  }
   .ml-6 {
     margin-left: calc(var(--spacing) * 6);
   }
@@ -1133,6 +1136,13 @@
       margin-block-end: calc(var(--stack-gap-lg) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
+  .space-y-0\.5 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 0.5) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 0.5) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
   .space-y-1 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
@@ -1654,6 +1664,9 @@
   .bg-\(--surface-subtle-background-color\) {
     background-color: var(--surface-subtle-background-color);
   }
+  .bg-\[oklch\(21\%_0\.01_250\)\] {
+    background-color: oklch(21% 0.01 250);
+  }
   .bg-\[var\(--accordion-background-color\)\] {
     background-color: var(--accordion-background-color);
   }
@@ -1896,6 +1909,9 @@
   }
   .bg-\[var\(--surface-page-background-color\)\] {
     background-color: var(--surface-page-background-color);
+  }
+  .bg-\[var\(--surface-subtle-background-color\)\] {
+    background-color: var(--surface-subtle-background-color);
   }
   .bg-\[var\(--switch-thumb-background-color\)\] {
     background-color: var(--switch-thumb-background-color);
@@ -2389,6 +2405,9 @@
   }
   .font-mono {
     font-family: var(--font-mono);
+  }
+  .font-sans {
+    font-family: var(--font-sans);
   }
   .text-2xl {
     font-size: var(--text-2xl);
@@ -3167,12 +3186,19 @@
   .will-change-transform {
     will-change: transform;
   }
+  .outline-none {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
   .select-none {
     -webkit-user-select: none;
     user-select: none;
   }
   .\[--button-border-radius\:9999px\] {
     --button-border-radius: 9999px;
+  }
+  .\[--button-focus-ring-color\:oklch\(72\%_0\.16_240\)\] {
+    --button-focus-ring-color: oklch(72% 0.16 240);
   }
   .\[--chat-message-meta-color\:var\(--chat-message-incoming-meta-color\)\] {
     --chat-message-meta-color: var(--chat-message-incoming-meta-color);
@@ -3186,8 +3212,28 @@
   .\[--chat-read-receipt-color\:var\(--chat-message-outgoing-read-receipt-color\)\] {
     --chat-read-receipt-color: var(--chat-message-outgoing-read-receipt-color);
   }
+  .\[--color-primary\:oklch\(72\%_0\.16_240\)\] {
+    --color-primary: oklch(72% 0.16 240);
+  }
+  .\[--surface-border-color\:oklch\(30\%_0\.02_250\)\] {
+    --surface-border-color: oklch(30% 0.02 250);
+  }
+  .\[--surface-content-color\:oklch\(88\%_0_0\)\] {
+    --surface-content-color: oklch(88% 0 0);
+  }
+  .\[--surface-muted-content-color\:oklch\(62\%_0_0\)\] {
+    --surface-muted-content-color: oklch(62% 0 0);
+  }
+  .\[--surface-subtle-background-color\:oklch\(28\%_0\.02_250\)\] {
+    --surface-subtle-background-color: oklch(28% 0.02 250);
+  }
   .\[scrollbar-width\:none\] {
     scrollbar-width: none;
+  }
+  .group-open\:rotate-90 {
+    &:is(:where(.group):is([open], :popover-open, :open) *) {
+      rotate: 90deg;
+    }
   }
   .peer-checked\:translate-x-4 {
     &:is(:where(.peer):checked ~ *) {
@@ -3510,6 +3556,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--surface-muted-background-color);
+      }
+    }
+  }
+  .hover\:bg-\[var\(--surface-subtle-background-color\)\] {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--surface-subtle-background-color);
       }
     }
   }
@@ -4117,6 +4170,11 @@
   .lg\:grid-cols-12 {
     @media (width >= 64rem) {
       grid-template-columns: repeat(12, minmax(0, 1fr));
+    }
+  }
+  .lg\:grid-cols-\[minmax\(0\,20rem\)_minmax\(0\,1fr\)\] {
+    @media (width >= 64rem) {
+      grid-template-columns: minmax(0,20rem) minmax(0,1fr);
     }
   }
   .lg\:p-12 {

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -58,7 +58,8 @@ class PagesController < ApplicationController
     {action: /\Acollapse\z/, title: "Collapse", patterns: [/\A--collapse-/]},
     {action: /\Askeletons\z/, title: "Skeleton", patterns: [/\A--skeleton-/]},
     {action: /\Atimeline\z/, title: "Timeline", patterns: [/\A--timeline-/]},
-    {action: /\Alist\z/, title: "List", patterns: [/\A--list-item-/]}
+    {action: /\Alist\z/, title: "List", patterns: [/\A--list-item-/]},
+    {action: /\Atree\z/, title: "Tree", patterns: []}
   ].freeze
 
   before_action :load_table_demo_data, only: %i[tables_basic tables_sortable tables_draggable]
@@ -644,6 +645,9 @@ class PagesController < ApplicationController
     @active_list_demo_item = params[:active_item].to_s
     valid_items = %w[buttons tables chat_demo search]
     @active_list_demo_item = "buttons" unless valid_items.include?(@active_list_demo_item)
+  end
+
+  def tree
   end
 
   def timeline
@@ -1456,6 +1460,7 @@ class PagesController < ApplicationController
       {title: "Collapse", description: "Expandable and collapsible content patterns", url: demo_collapse_path},
       {title: "Skeletons", description: "Skeleton loading placeholders", url: demo_skeletons_path},
       {title: "List", description: "List component demos and selectable rows", url: demo_list_path},
+      {title: "Tree", description: "Folder tree views for folder structures and hierarchical lists", url: demo_tree_path},
       {title: "Timeline", description: "Chronological timeline layouts", url: demo_timeline_path},
       {title: "Mobile", description: "Mobile demo index", url: mobile_path},
       {title: "Bottom Nav", description: "Mobile bottom navigation demo", url: mobile_bottom_nav_path}
@@ -1723,6 +1728,7 @@ class PagesController < ApplicationController
   def page_cache_version
     Digest::SHA256.hexdigest([
       page_template_cache_version,
+      component_cache_version,
       layout_stylesheet_cache_version,
       importmap_cache_version
     ].join("|")).first(12)
@@ -1737,6 +1743,25 @@ class PagesController < ApplicationController
     end
 
     Digest::SHA256.hexdigest(template_versions.join("|"))[0, 12]
+  end
+
+  def component_cache_version
+    component_roots = [
+      Rails.root.join("app/components"),
+      FlatPack::Engine.root.join("app/components")
+    ].uniq
+
+    component_files = component_roots.flat_map do |root|
+      Dir[root.join("**/*.rb")]
+    end.uniq.sort
+
+    component_versions = component_files.filter_map do |path|
+      next unless File.file?(path)
+
+      "#{path}:#{File.mtime(path).to_f}"
+    end
+
+    Digest::SHA256.hexdigest(component_versions.join("|"))[0, 12]
   end
 
   def layout_stylesheet_cache_version

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -448,6 +448,12 @@
                 active: false
               ) %>
               <%= render FlatPack::Sidebar::Item::Component.new(
+                label: "Tree",
+                href: demo_tree_path,
+                icon: :folder,
+                active: false
+              ) %>
+              <%= render FlatPack::Sidebar::Item::Component.new(
                 label: "Timeline",
                 href: demo_timeline_path,
                 icon: :calendar,

--- a/test/dummy/app/views/pages/_component_method_variables_table.html.erb
+++ b/test/dummy/app/views/pages/_component_method_variables_table.html.erb
@@ -624,6 +624,16 @@
         { variable: "tab / panel", accepts: "id:, label:, block", example: "tabs.tab(id: \"overview\", label: \"Overview\")" }
       ]
     },
+    tree: {
+      label: "Tree",
+      method_call: "render FlatPack::Tree::Component.new(compact: true, guides: true) do |tree| ... end",
+      variables: [
+        { variable: "compact", accepts: "true, false", example: "compact: true" },
+        { variable: "guides", accepts: "true, false", example: "guides: false" },
+        { variable: "node", accepts: "label:, href:, icon:, expanded:, active:, meta:, block", example: "tree.node(label: \"src\", expanded: true) { |node| node.node(label: \"App.js\") }" },
+        { variable: "**system_arguments", accepts: "Hash", example: "class: \"max-w-sm\", data: { testid: \"tree\" }" }
+      ]
+    },
     timeline: {
       label: "Timeline",
       method_call: "render FlatPack::Timeline::Component.new(class: \"max-w-2xl\") do ... end",

--- a/test/dummy/app/views/pages/tree.html.erb
+++ b/test/dummy/app/views/pages/tree.html.erb
@@ -1,0 +1,106 @@
+<%= render FlatPack::PageTitle::Component.new(
+  title: "Tree Component",
+  subtitle: "Expandable hierarchical trees for folder structures, navigation, and nested content lists."
+) %>
+
+<%= render "pages/component_method_variables_table", component: :tree %>
+
+<section class="mb-12">
+  <%= render FlatPack::SectionTitle::Component.new(
+    title: "VS Code-style File Tree",
+    anchor_link: true,
+    subtitle: "A compact folder explorer inspired by editor sidebars, built entirely from the Tree component API."
+  ) %>
+
+  <%= render FlatPack::Card::Component.new(class: "mt-6 max-w-xl overflow-hidden") do |card| %>
+    <% card.body(class: "p-0") do %>
+      <div class="bg-[oklch(21%_0.01_250)] [--surface-content-color:oklch(88%_0_0)] [--surface-muted-content-color:oklch(62%_0_0)] [--surface-border-color:oklch(30%_0.02_250)] [--surface-subtle-background-color:oklch(28%_0.02_250)] [--button-focus-ring-color:oklch(72%_0.16_240)] [--color-primary:oklch(72%_0.16_240)]">
+        <%= render FlatPack::Tree::Component.new(compact: true, class: "w-64 p-2 font-sans") do |tree| %>
+          <% tree.node(label: "src", expanded: true, icon: :folder) do |src| %>
+            <% src.node(label: "components", expanded: true, icon: :folder) do |components| %>
+              <% components.node(label: "Button.tsx", icon: "code-bracket-square") %>
+              <% components.node(label: "Card.tsx", icon: "code-bracket-square") %>
+            <% end %>
+
+            <% src.node(label: "App.js", icon: "code-bracket-square", active: true) %>
+            <% src.node(label: "index.css", icon: "paint-brush") %>
+          <% end %>
+
+          <% tree.node(label: "package.json", icon: "document-text") %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <%= render FlatPack::CodeBlock::Component.new(
+    class: "mt-6",
+    language: "erb",
+    title: "VS Code-style File Tree",
+    code: CGI.unescapeHTML(<<~'CODE'),
+      &lt;div class=&quot;bg-[oklch(21%_0.01_250)] [--surface-content-color:oklch(88%_0_0)] [--surface-muted-content-color:oklch(62%_0_0)] [--surface-border-color:oklch(30%_0.02_250)] [--surface-subtle-background-color:oklch(28%_0.02_250)] [--button-focus-ring-color:oklch(72%_0.16_240)] [--color-primary:oklch(72%_0.16_240)]&quot;&gt;
+        &lt;%= render FlatPack::Tree::Component.new(compact: true, class: &quot;w-64 p-2 font-sans&quot;) do |tree| %&gt;
+          &lt;% tree.node(label: &quot;src&quot;, expanded: true, icon: :folder) do |src| %&gt;
+            &lt;% src.node(label: &quot;components&quot;, expanded: true, icon: :folder) do |components| %&gt;
+              &lt;% components.node(label: &quot;Button.tsx&quot;, icon: &quot;code-bracket-square&quot;) %&gt;
+              &lt;% components.node(label: &quot;Card.tsx&quot;, icon: &quot;code-bracket-square&quot;) %&gt;
+            &lt;% end %&gt;
+
+            &lt;% src.node(label: &quot;App.js&quot;, icon: &quot;code-bracket-square&quot;, active: true) %&gt;
+            &lt;% src.node(label: &quot;index.css&quot;, icon: &quot;paint-brush&quot;) %&gt;
+          &lt;% end %&gt;
+
+          &lt;% tree.node(label: &quot;package.json&quot;, icon: &quot;document-text&quot;) %&gt;
+        &lt;% end %&gt;
+      &lt;/div&gt;
+    CODE
+  ) %>
+</section>
+
+<section class="mb-12">
+  <%= render FlatPack::SectionTitle::Component.new(
+    title: "Nested Navigation List",
+    anchor_link: true,
+    subtitle: "The same component can also render expandable documentation or settings navigation trees."
+  ) %>
+
+  <div class="mt-6 grid gap-6 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]">
+    <%= render FlatPack::Card::Component.new do |card| %>
+      <% card.body do %>
+        <%= render FlatPack::Tree::Component.new(class: "max-w-sm") do |tree| %>
+          <% tree.node(label: "Getting Started", expanded: true, icon: "rocket-launch") do |section| %>
+            <% section.node(label: "Installation", href: "#installation", icon: "document-text") %>
+            <% section.node(label: "Theming", href: "#theming", icon: "swatch") %>
+          <% end %>
+
+          <% tree.node(label: "Components", expanded: true, icon: :folder) do |section| %>
+            <% section.node(label: "Buttons", href: demo_buttons_path, icon: "cursor-arrow-rays") %>
+            <% section.node(label: "Tables", href: demo_tables_basic_path, icon: "table-cells") %>
+            <% section.node(label: "Tree", href: demo_tree_path, icon: :folder, active: true, meta: "New" ) %>
+          <% end %>
+
+          <% tree.node(label: "Changelog", href: "#changelog", icon: "clock") %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= render FlatPack::Card::Component.new do |card| %>
+      <% card.body(class: "space-y-4") do %>
+        <p class="text-sm text-(--surface-muted-content-color)">
+          Tree is useful when the relationship between items matters as much as the items themselves. Use it for file explorers, docs sidebars, settings panels, or any expandable nested list where parent-child structure should stay visible.
+        </p>
+
+        <%= render FlatPack::List::Component.new(spacing: :dense, class: "text-sm") do %>
+          <%= render FlatPack::List::Item.new(icon: "folder") do %>
+            Expand groups by nesting <code>node</code> calls inside a parent node block.
+          <% end %>
+          <%= render FlatPack::List::Item.new(icon: "document-text") do %>
+            Pass <code>href:</code> for leaf nodes that should act like navigation links.
+          <% end %>
+          <%= render FlatPack::List::Item.new(icon: "paint-brush") do %>
+            Override row styling with per-node <code>class:</code> values to match brand or product-specific shells.
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</section>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -132,6 +132,7 @@ Rails.application.routes.draw do
   get "demo/range_input", to: "pages#range_input"
   get "demo/skeletons", to: "pages#skeletons"
   get "demo/list", to: "pages#list"
+  get "demo/tree", to: "pages#tree"
   get "demo/timeline", to: "pages#timeline"
 
   # Form submission endpoints for demonstration

--- a/test/dummy/test/controllers/pages_controller_private_test.rb
+++ b/test/dummy/test/controllers/pages_controller_private_test.rb
@@ -8,6 +8,7 @@ class PagesControllerPrivateTest < ActiveSupport::TestCase
     request = OpenStruct.new(path: "/demo/tables/basic")
     controller.define_singleton_method(:request) { request }
     controller.define_singleton_method(:page_template_cache_version) { "templates-old" }
+    controller.define_singleton_method(:component_cache_version) { "components" }
     controller.define_singleton_method(:layout_stylesheet_cache_version) { "styles" }
     controller.define_singleton_method(:importmap_cache_version) { "importmap" }
     old_key = controller.send(:page_cache_key)
@@ -24,6 +25,7 @@ class PagesControllerPrivateTest < ActiveSupport::TestCase
     request = OpenStruct.new(path: "/demo/tables/basic")
     controller.define_singleton_method(:request) { request }
     controller.define_singleton_method(:page_template_cache_version) { "templates" }
+    controller.define_singleton_method(:component_cache_version) { "components" }
     controller.define_singleton_method(:layout_stylesheet_cache_version) { "styles-old" }
     controller.define_singleton_method(:importmap_cache_version) { "importmap" }
     old_key = controller.send(:page_cache_key)
@@ -39,6 +41,7 @@ class PagesControllerPrivateTest < ActiveSupport::TestCase
     request = OpenStruct.new(path: "/demo/tables/basic")
     controller.define_singleton_method(:request) { request }
     controller.define_singleton_method(:page_template_cache_version) { "templates" }
+    controller.define_singleton_method(:component_cache_version) { "components" }
     controller.define_singleton_method(:layout_stylesheet_cache_version) { "styles" }
     controller.define_singleton_method(:importmap_cache_version) { "importmap-old" }
     old_key = controller.send(:page_cache_key)
@@ -47,6 +50,23 @@ class PagesControllerPrivateTest < ActiveSupport::TestCase
     new_key = controller.send(:page_cache_key)
 
     refute_equal old_key, new_key
+  end
+
+  test "page_cache_key changes when component version changes" do
+    controller = PagesController.new
+    request = OpenStruct.new(path: "/demo/tree")
+    controller.define_singleton_method(:request) { request }
+    controller.define_singleton_method(:page_template_cache_version) { "templates" }
+    controller.define_singleton_method(:component_cache_version) { "components-old" }
+    controller.define_singleton_method(:layout_stylesheet_cache_version) { "styles" }
+    controller.define_singleton_method(:importmap_cache_version) { "importmap" }
+    old_key = controller.send(:page_cache_key)
+
+    controller.define_singleton_method(:component_cache_version) { "components-new" }
+    new_key = controller.send(:page_cache_key)
+
+    refute_equal old_key, new_key
+    assert_includes new_key, request.path
   end
 
   private

--- a/test/dummy/test/requests/pages_demo_routes_test.rb
+++ b/test/dummy/test/requests/pages_demo_routes_test.rb
@@ -80,6 +80,7 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
     /demo/range_input
     /demo/skeletons
     /demo/list
+    /demo/tree
     /demo/timeline
     /mobile
     /mobile/bottom_nav
@@ -545,6 +546,12 @@ class PagesDemoRoutesTest < ActionDispatch::IntegrationTest
     assert_response :success
     payload = JSON.parse(response.body)
     assert payload["results"].any? { |entry| entry["title"] == "Timeline" }
+
+    get "/demo/search_results", params: {q: "folder tree"}
+
+    assert_response :success
+    payload = JSON.parse(response.body)
+    assert payload["results"].any? { |entry| entry["title"] == "Tree" }
   end
 
   test "top nav includes live demo search" do

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.37] - 2026-05-05
+
+### Added
+- Added a new dummy Text Content demo page under `/demo/text/content` to showcase long-form editorial and marketing copy with primary-theme color accents.
+- Added a new `FlatPack::Tree::Component` plus `/demo/tree` examples for VS Code-style folder explorers and nested list navigation.
+
+### Changed
+- Added `rich_text` and `rich_text_options` pass-through support to the comments composer and inline input wrappers so reply and comment fields can opt into the shared TipTap-backed `TextArea` editor while remaining plain text by default.
+
+### Fixed
+- Restored the dummy app importmap's missing `@tiptap/*` package pins so rich-text comment and textarea demos can actually boot the `flat-pack--tiptap` controller in the browser.
+- Explicitly registered the dummy app's `flat-pack--tiptap` Stimulus controller so rich-text demos do not rely solely on nested lazy controller discovery at first paint.
+- Added component file versions to the dummy app's full-page cache key so component-only demo updates, including the new Tree markup, no longer serve stale cached HTML until the cache expires.
+
 ## [0.1.32] - 2026-04-27
 
 ### Added

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/tree/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/tree/component.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+module FlatPack
+  module Tree
+    class Component < FlatPack::BaseComponent
+      Node = Struct.new(
+        :label,
+        :href,
+        :icon,
+        :expanded,
+        :active,
+        :meta,
+        :children,
+        :system_arguments,
+        keyword_init: true
+      )
+
+      class Builder
+        attr_reader :nodes
+
+        def initialize(component)
+          @component = component
+          @nodes = []
+        end
+
+        def node(label:, href: nil, icon: nil, expanded: false, active: false, meta: nil, **system_arguments, &block)
+          @nodes << @component.send(
+            :build_node,
+            label: label,
+            href: href,
+            icon: icon,
+            expanded: expanded,
+            active: active,
+            meta: meta,
+            system_arguments: system_arguments,
+            &block
+          )
+        end
+      end
+
+      def initialize(compact: false, guides: true, **system_arguments)
+        super(**system_arguments)
+        @compact = compact
+        @guides = guides
+        @nodes = []
+      end
+
+      def node(label:, href: nil, icon: nil, expanded: false, active: false, meta: nil, **system_arguments, &block)
+        @nodes << build_node(
+          label: label,
+          href: href,
+          icon: icon,
+          expanded: expanded,
+          active: active,
+          meta: meta,
+          system_arguments: system_arguments,
+          &block
+        )
+      end
+
+      def call
+        content
+
+        content_tag(:div, **tree_attributes) do
+          safe_join(@nodes.map.with_index { |tree_node, index| render_node(tree_node, level: 1, index: index) })
+        end
+      end
+
+      private
+
+      def build_node(label:, href:, icon:, expanded:, active:, meta:, system_arguments:, &block)
+        child_builder = Builder.new(self)
+        block&.call(child_builder)
+
+        sanitized_href = sanitize_url(href)
+        validate_href!(href, sanitized_href)
+
+        Node.new(
+          label: label,
+          href: sanitized_href,
+          icon: icon || default_icon(child_builder.nodes.any?),
+          expanded: expanded,
+          active: active,
+          meta: meta,
+          children: child_builder.nodes,
+          system_arguments: sanitize_args(system_arguments)
+        )
+      end
+
+      def render_node(tree_node, level:, index:)
+        return render_leaf_node(tree_node, level: level, index: index) if tree_node.children.empty?
+
+        content_tag(:details, open: tree_node.expanded, class: "group space-y-0.5") do
+          safe_join([
+            content_tag(:summary, render_branch_row(tree_node, level: level), **summary_attributes(tree_node, level: level)),
+            content_tag(:div, safe_join(tree_node.children.map.with_index { |child, child_index| render_node(child, level: level + 1, index: child_index) }), **children_attributes)
+          ])
+        end
+      end
+
+      def render_branch_row(tree_node, level:)
+        safe_join([
+          render_active_indicator(tree_node),
+          content_tag(:span, render_chevron_icon, class: "flex h-4 w-4 items-center justify-center text-[var(--surface-muted-content-color)] transition-transform group-open:rotate-90"),
+          render_node_icon(tree_node),
+          content_tag(:span, tree_node.label, class: branch_label_classes(level)),
+          render_meta(tree_node)
+        ].compact)
+      end
+
+      def render_leaf_node(tree_node, level:, index:)
+        row = render_leaf_row(tree_node, level: level)
+
+        content_tag(:div, **leaf_wrapper_attributes(tree_node, level: level, index: index)) do
+          if tree_node.href.present?
+            link_to(tree_node.href, class: "flex min-w-0 flex-1 items-center gap-1.5", aria: {current: ("page" if tree_node.active)}) { row }
+          else
+            row
+          end
+        end
+      end
+
+      def render_leaf_row(tree_node, level:)
+        safe_join([
+          render_active_indicator(tree_node),
+          content_tag(:span, nil, class: "block h-4 w-4 flex-none"),
+          render_node_icon(tree_node),
+          content_tag(:span, tree_node.label, class: leaf_label_classes(level)),
+          render_meta(tree_node)
+        ].compact)
+      end
+
+      def render_active_indicator(tree_node)
+        return unless tree_node.active
+
+        content_tag(:span, nil, class: "absolute inset-y-0 left-0 w-0.5 rounded-full bg-[var(--color-primary)]")
+      end
+
+      def render_chevron_icon
+        render FlatPack::Shared::IconComponent.new(name: "chevron-right", size: :sm)
+      end
+
+      def render_node_icon(tree_node)
+        return unless tree_node.icon.present?
+
+        content_tag(:span, class: "flex h-4 w-4 flex-none items-center justify-center text-[var(--surface-muted-content-color)]") do
+          render FlatPack::Shared::IconComponent.new(name: tree_node.icon, size: :sm)
+        end
+      end
+
+      def render_meta(tree_node)
+        return if tree_node.meta.blank?
+
+        content_tag(:span, tree_node.meta, class: "ml-auto truncate text-xs text-[var(--surface-muted-content-color)]")
+      end
+
+      def tree_attributes
+        merge_attributes(
+          class: tree_classes,
+          role: "tree"
+        )
+      end
+
+      def tree_classes
+        classes(
+          "w-full text-sm text-[var(--surface-content-color)] select-none",
+          ("space-y-0.5" unless @compact)
+        )
+      end
+
+      def summary_attributes(tree_node, level:)
+        merge_node_attributes(
+          tree_node,
+          class: row_classes(tree_node),
+          role: "treeitem",
+          tabindex: 0,
+          aria: {
+            expanded: tree_node.expanded,
+            selected: tree_node.active,
+            level: level
+          }
+        )
+      end
+
+      def children_attributes
+        {
+          class: children_classes,
+          role: "group"
+        }
+      end
+
+      def children_classes
+        classes(
+          "ml-3.5 mt-0.5 pl-2 space-y-0.5",
+          ("border-l border-[var(--surface-border-color)]" if @guides)
+        )
+      end
+
+      def leaf_wrapper_attributes(tree_node, level:, index:)
+        merge_node_attributes(
+          tree_node,
+          class: row_classes(tree_node),
+          role: "treeitem",
+          tabindex: 0,
+          aria: {
+            selected: tree_node.active,
+            level: level,
+            posinset: index + 1
+          }
+        )
+      end
+
+      def row_classes(tree_node)
+        classes(
+          "group relative flex items-center gap-1.5 overflow-hidden rounded-[var(--radius-sm)] px-2 text-left transition-colors outline-none",
+          row_padding_classes,
+          "hover:bg-[var(--surface-subtle-background-color)] focus-visible:ring-2 focus-visible:ring-[var(--button-focus-ring-color)] focus-visible:ring-inset",
+          ("bg-[var(--surface-subtle-background-color)]" if tree_node.active),
+          tree_node.system_arguments[:class]
+        )
+      end
+
+      def row_padding_classes
+        @compact ? "py-1" : "py-1.5"
+      end
+
+      def branch_label_classes(level)
+        classes(
+          "min-w-0 truncate",
+          ("font-medium" if level <= 2)
+        )
+      end
+
+      def leaf_label_classes(_level)
+        classes("min-w-0 truncate")
+      end
+
+      def merge_node_attributes(tree_node, **additional_attrs)
+        node_attributes = tree_node.system_arguments.dup
+        node_class = node_attributes.delete(:class)
+        node_data = node_attributes.delete(:data) || {}
+        node_aria = node_attributes.delete(:aria) || {}
+
+        {
+          class: TailwindMerge::Merger.new.merge([additional_attrs.delete(:class), node_class].compact.join(" ")),
+          data: node_data.merge(additional_attrs.delete(:data) || {}),
+          aria: node_aria.merge(additional_attrs.delete(:aria) || {})
+        }.merge(node_attributes).merge(additional_attrs).compact
+      end
+
+      def default_icon(branch)
+        branch ? :folder : "document-text"
+      end
+
+      def sanitize_url(url)
+        return nil if url.nil?
+
+        FlatPack::AttributeSanitizer.sanitize_url(url)
+      end
+
+      def validate_href!(original_url, sanitized_url)
+        return unless original_url.present?
+        return if sanitized_url.present?
+
+        raise ArgumentError, "Unsafe URL detected. Only http, https, mailto, tel protocols and relative URLs are allowed."
+      end
+    end
+  end
+end

--- a/test/dummy/vendor/flat_pack/docs/components/tree.md
+++ b/test/dummy/vendor/flat_pack/docs/components/tree.md
@@ -1,0 +1,65 @@
+# Tree
+
+## Purpose
+Render expandable hierarchical trees for folder explorers, nested navigation, and structured parent-child content.
+
+## When to use
+Use Tree when users need to scan and expand nested relationships such as file systems, documentation sidebars, or grouped settings sections.
+
+## Class
+- Primary: `FlatPack::Tree::Component`
+
+## Props
+`FlatPack::Tree::Component`:
+
+| name | type | default | required | description |
+|---|---|---|---|---|
+| `compact` | Boolean | `false` | no | Uses tighter vertical row spacing for dense explorer-style trees. |
+| `guides` | Boolean | `true` | no | Shows or hides the vertical guide lines between nested groups. |
+| `**system_arguments` | Hash | `{}` | no | HTML attributes for the tree wrapper (`role="tree"`). |
+
+`tree.node(...)` builder arguments:
+
+| name | type | default | required | description |
+|---|---|---|---|---|
+| `label` | String | `nil` | yes | Visible text label for the node. |
+| `href` | String | `nil` | no | Optional link URL for leaf nodes. Unsafe URLs raise `ArgumentError`. |
+| `icon` | Symbol/String | auto | no | Optional shared icon name. Defaults to folder for branches and document text for leaves. |
+| `expanded` | Boolean | `false` | no | Starts branch nodes open when true. Ignored for leaf nodes. |
+| `active` | Boolean | `false` | no | Applies the active row state and selection styling. |
+| `meta` | String | `nil` | no | Optional trailing helper text, count, or status label. |
+| `**system_arguments` | Hash | `{}` | no | Extra HTML attributes merged onto the rendered row. |
+
+## Slots
+- The component uses a nested builder DSL via `tree.node(...) do |node| ... end`.
+- Nest additional `node.node(...)` calls inside a parent block to create child groups.
+
+## Variants
+- Standard or dense layout via `compact`.
+- Guide lines on or off via `guides`.
+- Branch nodes with nested children or leaf nodes with optional links.
+
+## Example
+```erb
+<%= render FlatPack::Tree::Component.new(compact: true) do |tree| %>
+  <% tree.node(label: "src", expanded: true) do |src| %>
+    <% src.node(label: "components", expanded: true) do |components| %>
+      <% components.node(label: "Button.tsx") %>
+      <% components.node(label: "Card.tsx") %>
+    <% end %>
+
+    <% src.node(label: "App.js", active: true) %>
+  <% end %>
+
+  <% tree.node(label: "package.json") %>
+<% end %>
+```
+
+## Accessibility
+- The wrapper renders with `role="tree"`.
+- Branch and leaf rows render with `role="treeitem"` and selection state.
+- Nested containers render with `role="group"`.
+- Interactive links remain keyboard-focusable when `href` is provided.
+
+## Dependencies
+- FlatPack install generator setup (`rails generate flat_pack:install`).

--- a/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
+++ b/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.32"
+  VERSION = "0.1.37"
 end


### PR DESCRIPTION
Introduce a new `FlatPack::Tree::Component` along with demo examples for folder navigation. Update the gem version to 0.1.37 and enhance the changelog with relevant details.