### PR TITLE
Fix breadcrumb rendering and update version to 0.1.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed `FlatPack::Breadcrumb::Component` so combined Back and Home trails render Home only once, kept the Back link spacing consistent, and refreshed the dummy breadcrumb example.
 - Updated text input and shared form-validation warning states to use the semantic `var(--color-warning)` token in both server-rendered and JS-driven validation flows.
+- Refreshed the root and dummy bundle lockfiles to resolve `addressable` and `rack-session` to patched versions for the current `bundle-audit` advisories.
 
 ### Tests
 - Added breadcrumb regression coverage for the Back + Home rendering path and class merging on breadcrumb links.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the locked `nokogiri` versions in the root and dummy app bundle files to `1.19.3` to address the published security advisories.
 - Updated the root bundle lockfile to `rack 3.2.6` to address the published CVEs affecting static file handling and multipart byte-range processing.
 
+## [0.1.58] - 2026-05-13
+
+### Fixed
+- Fixed `FlatPack::Breadcrumb::Component` so combined Back and Home trails render Home only once, kept the Back link spacing consistent, and refreshed the dummy breadcrumb example.
+- Updated text input and shared form-validation warning states to use the semantic `var(--color-warning)` token in both server-rendered and JS-driven validation flows.
+
+### Tests
+- Added breadcrumb regression coverage for the Back + Home rendering path and class merging on breadcrumb links.
+- Added focused regression coverage for the text input warning token classes and a Node-based test for the shared form-validation controller.
+
 ## [0.1.57] - 2026-05-12
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
@@ -204,7 +204,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -393,7 +393,7 @@ CHECKSUMS
   activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
-  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
@@ -455,7 +455,7 @@ CHECKSUMS
   puma (7.1.0) sha256=e45c10cb124f224d448c98db653a75499794edbecadc440ad616cf50f2fd49dd
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
-  rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.57)
+    flat_pack (0.1.58)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -412,7 +412,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.57)
+  flat_pack (0.1.58)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -6,11 +6,11 @@ This document summarizes the current FlatPack repository layout and the files th
 
 **FlatPack** is a Rails engine that ships ViewComponent-based UI components, Tailwind CSS 4 token styling, Propshaft-served assets, and importmap-friendly JavaScript.
 
-**Version:** 0.1.57
+**Version:** 0.1.58
 **License:** MIT  
 **Ruby:** 3.2+  
 **Supported host apps:** Rails 7.1+  
-**Last Updated:** 2026-05-12
+**Last Updated:** 2026-05-13
 
 ## Repository Layout
 

--- a/app/components/flat_pack/breadcrumb/component.rb
+++ b/app/components/flat_pack/breadcrumb/component.rb
@@ -94,10 +94,11 @@ module FlatPack
 
         # Add back item if requested
         if @show_back
-          items_list << item(
+          items_list << build_internal_item(
             text: @back_text,
             href: resolved_back_href(breadcrumb_items),
-            icon: @back_icon
+            icon: @back_icon,
+            class: "mr-3"
           )
         end
 
@@ -109,7 +110,7 @@ module FlatPack
 
         # Add home item if requested
         if @show_home
-          items_list << item(
+          items_list << build_internal_item(
             text: @home_text,
             href: @home_url,
             icon: @home_icon
@@ -125,6 +126,10 @@ module FlatPack
 
       def previous_breadcrumb_href(breadcrumb_items)
         breadcrumb_items[0...-1].reverse_each.find(&:href)&.href
+      end
+
+      def build_internal_item(**kwargs)
+        FlatPack::Breadcrumb::Item::Component.new(**kwargs)
       end
 
       def maybe_collapse_items(items_list)

--- a/app/components/flat_pack/breadcrumb/item/component.rb
+++ b/app/components/flat_pack/breadcrumb/item/component.rb
@@ -45,10 +45,17 @@ module FlatPack
         def render_link_item
           link_to(href,
             {
-              class: "flex items-center text-[var(--breadcrumb-link-color)] hover:text-[var(--breadcrumb-link-hover-color)] transition-colors"
-            }.merge(@system_arguments)) do
+              class: link_classes
+            }.merge(@system_arguments.except(:class))) do
             item_content
           end
+        end
+
+        def link_classes
+          [
+            "flex items-center text-[var(--breadcrumb-link-color)] hover:text-[var(--breadcrumb-link-hover-color)] transition-colors",
+            @system_arguments[:class]
+          ].compact.join(" ")
         end
 
         def item_content

--- a/app/components/flat_pack/text_input/component.rb
+++ b/app/components/flat_pack/text_input/component.rb
@@ -102,7 +102,7 @@ module FlatPack
         ]
 
         base_classes << if @error
-          "border-warning"
+          "border-[var(--color-warning)]"
         else
           "border-[var(--surface-border-color)]"
         end
@@ -111,7 +111,7 @@ module FlatPack
       end
 
       def error_classes
-        "mt-1 text-sm text-warning"
+        "mt-1 text-sm text-[var(--color-warning)]"
       end
 
       def input_id

--- a/app/javascript/flat_pack/controllers/form_validation_controller.js
+++ b/app/javascript/flat_pack/controllers/form_validation_controller.js
@@ -104,7 +104,7 @@ export default class extends Controller {
     errorNode.classList.remove("hidden")
 
     // Apply a visible invalid border for JS-driven validation states.
-    this.element.classList.add("border-warning")
+    this.element.classList.add("border-[var(--color-warning)]")
     this.element.style.borderColor = "var(--color-warning)"
 
     this.element.setAttribute("aria-invalid", "true")
@@ -118,7 +118,7 @@ export default class extends Controller {
       errorNode.textContent = ""
     }
 
-    this.element.classList.remove("border-warning")
+    this.element.classList.remove("border-[var(--color-warning)]")
     if (this.initialBorderColor) {
       this.element.style.borderColor = this.initialBorderColor
     } else {
@@ -143,7 +143,7 @@ export default class extends Controller {
 
     const node = document.createElement("p")
     node.id = this.errorIdValue
-    node.className = "mt-1 text-sm text-warning hidden"
+    node.className = "mt-1 text-sm text-[var(--color-warning)] hidden"
 
     const container = this.errorContainer()
     if (container) {

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-05-12",
+  "updated_at": "2026-05-13",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.57"
+    "version": "0.1.58"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This document provides the exact terminal commands and configuration steps neede
 
 FlatPack is a modern Rails UI Component Library built with ViewComponent, Tailwind CSS, and Hotwire. It provides type-safe, testable components with dark mode support and accessibility features. Supports Rails 7.1 and above.
 
-**Current Version:** 0.1.57 (Updated May 12, 2026)
+**Current Version:** 0.1.58 (Updated May 13, 2026)
 
 ## AI-first installation entrypoint
 

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.57"
+  VERSION = "0.1.58"
 end

--- a/test/components/flat_pack/breadcrumb_component_test.rb
+++ b/test/components/flat_pack/breadcrumb_component_test.rb
@@ -138,7 +138,7 @@ module FlatPack
           breadcrumb.item(text: "Products", href: "/products")
         end
 
-        assert_selector "a[href='/']", text: "Home"
+        assert_selector "a[href='/']", text: "Home", count: 1
         assert_selector "svg[data-flat-pack--icon-name-value='home']"
       end
 
@@ -183,6 +183,7 @@ module FlatPack
 
         assert_selector "a[href='/previous']", text: "Back"
         assert_selector "nav ol li:first-child a[href='/previous']", text: "Back"
+        assert_selector "a[href='/previous'].mr-3", text: "Back", count: 1
         assert_selector "svg[data-flat-pack--icon-name-value='chevron-left']"
       end
 
@@ -232,13 +233,23 @@ module FlatPack
         assert_operator html.index("Back"), :<, html.index("Home")
       end
 
+      def test_renders_home_only_once_when_back_and_home_are_enabled
+        render_inline(Component.new(show_back: true, back_href: "/back", show_home: true)) do |breadcrumb|
+          breadcrumb.item(text: "Create ordered list")
+        end
+
+        assert_selector "a[href='/back']", text: "Back", count: 1
+        assert_selector "a[href='/']", text: "Home", count: 1
+        assert_selector "span[aria-current='page']", text: "Create ordered list", count: 1
+      end
+
       def test_hides_separator_to_the_right_of_back_item
-        render_inline(Component.new(show_back: true, show_home: true, back_fallback_url: "/previous")) do |breadcrumb|
+        render_inline(Component.new(show_back: true, show_home: true, back_href: "/previous")) do |breadcrumb|
           breadcrumb.item(text: "Current")
         end
 
-        assert_selector "a[href='/']", text: "Back"
-        assert_selector "a[href='/']", text: "Home"
+        assert_selector "a[href='/previous']", text: "Back", count: 1
+        assert_selector "a[href='/']", text: "Home", count: 1
         assert_no_selector "nav[aria-label='Breadcrumb'] li:first-child + li[aria-hidden='true']"
         assert_selector "nav[aria-label='Breadcrumb'] li[aria-hidden='true']"
       end
@@ -410,6 +421,14 @@ module FlatPack
         render_inline(Item::Component.new(text: "Home", href: "/"))
 
         assert_includes page.native.to_html, "hover:text-[var(--breadcrumb-link-hover-color)]"
+        assert_includes page.native.to_html, "transition-colors"
+      end
+
+      def test_item_merges_custom_link_classes
+        render_inline(Item::Component.new(text: "Home", href: "/", class: "mr-3"))
+
+        assert_selector "a[href='/'].mr-3", text: "Home"
+        assert_includes page.native.to_html, "text-[var(--breadcrumb-link-color)]"
         assert_includes page.native.to_html, "transition-colors"
       end
 

--- a/test/components/flat_pack/text_input_component_test.rb
+++ b/test/components/flat_pack/text_input_component_test.rb
@@ -60,9 +60,9 @@ module FlatPack
       def test_error_styles_applied
         render_inline(Component.new(name: "username", error: "Invalid"))
 
-        # Check that destructive border color is applied
         html = page.native.to_html
-        assert_includes html, "border-warning"
+        assert_includes html, "border-[var(--color-warning)]"
+        assert_includes html, "text-[var(--color-warning)]"
       end
 
       def test_renders_with_custom_class

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.57)
+    flat_pack (0.1.58)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -313,7 +313,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.57)
+  flat_pack (0.1.58)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     benchmark (0.5.0)
@@ -298,7 +298,7 @@ CHECKSUMS
   activerecord (7.2.3.1) sha256=b89513e275da5b34183c5f2a497c154b02dcc7c811d399ab557e67e36170a05d
   activestorage (7.2.3.1) sha256=0b224ea42e6256d3e33768bdccad8e3c9110a5140fc9faf98bde8873dd5dffab
   activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
-  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca

--- a/test/dummy/Gemfile.app_platform.lock
+++ b/test/dummy/Gemfile.app_platform.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.57)
+    flat_pack (0.1.58)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -371,7 +371,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.57)
+  flat_pack (0.1.58)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -187,7 +187,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     puma (7.1.0)
       nio4r (~> 2.0)
     racc (1.8.1)

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.57)
+    flat_pack (0.1.58)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/app/assets/builds/application.css
+++ b/test/dummy/app/assets/builds/application.css
@@ -1608,6 +1608,9 @@
   .border-\[var\(--color-success-border\)\] {
     border-color: var(--color-success-border);
   }
+  .border-\[var\(--color-warning\)\] {
+    border-color: var(--color-warning);
+  }
   .border-\[var\(--color-warning-border\)\] {
     border-color: var(--color-warning-border);
   }
@@ -2786,6 +2789,9 @@
   }
   .text-\[var\(--color-success-text\)\] {
     color: var(--color-success-text);
+  }
+  .text-\[var\(--color-warning\)\] {
+    color: var(--color-warning);
   }
   .text-\[var\(--color-warning-border\)\] {
     color: var(--color-warning-border);

--- a/test/dummy/app/views/pages/breadcrumbs.html.erb
+++ b/test/dummy/app/views/pages/breadcrumbs.html.erb
@@ -125,13 +125,16 @@
   <!-- With Back Item -->
   <section class="mb-12">
     <%= render FlatPack::SectionTitle::Component.new(title: "With Back Item", anchor_link: true, subtitle: "Examples for With Back Item.") %>
-    <p class="text-sm text-[var(--surface-muted-content-color)] mb-3">
-      The back link is prepended as the first breadcrumb item and resolves to the previous linked breadcrumb level by default.
+    <p class="text-sm text-(--surface-muted-content-color) mb-3">
+      The back link is prepended first. When combined with show_home, Home is rendered once before declared items.
     </p>
     <div class="mb-4">
       <%= render FlatPack::Breadcrumb::Component.new(
         show_back: true,
-        back_fallback_url: "/demo"
+        back_href: "javascript:window.history.back()",
+        show_home: true,
+        home_url: demo_path,
+        class: "mb-2"
       ) do |breadcrumb| %>
         <% breadcrumb.item(text: "Settings", href: "/settings") %>
         <% breadcrumb.item(text: "Profile") %>
@@ -141,12 +144,15 @@
       code: CGI.unescapeHTML(<<~'CODE')
         &lt;%= render FlatPack::Breadcrumb::Component.new(
           show_back: true,
-          back_fallback_url: "/demo"
+          back_href: "javascript:window.history.back()",
+          show_home: true,
+          home_url: demo_path,
+          class: "mb-2"
         ) do |breadcrumb| %&gt;
           &lt;% breadcrumb.item(text: "Settings", href: "/settings") %&gt;
           &lt;% breadcrumb.item(text: "Profile") %&gt;
         &lt;% end %&gt;
-        &lt;!-- Back resolves to /settings here, and falls back to /demo only when no earlier linked item exists. --&gt;
+        &lt;!-- Back uses the explicit history target, and Home is rendered only once. --&gt;
       CODE
     ) %>
   </section>

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.58] - 2026-05-13
+
+### Fixed
+- Fixed the breadcrumb Back + Home rendering path so Home appears once, kept the Back link spacing consistent, and refreshed the dummy breadcrumb example.
+- Updated server-rendered and JS-driven text input warning states to use the semantic `var(--color-warning)` token.
+
+### Tests
+- Added breadcrumb regression coverage for duplicate Home prevention and breadcrumb link class merging.
+- Added focused text input warning coverage and a Node-based regression test for the shared form-validation controller.
+
 ## [0.1.57] - 2026-05-12
 
 ### Changed

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the breadcrumb Back + Home rendering path so Home appears once, kept the Back link spacing consistent, and refreshed the dummy breadcrumb example.
 - Updated server-rendered and JS-driven text input warning states to use the semantic `var(--color-warning)` token.
+- Refreshed the root and dummy bundle lockfiles to resolve `addressable` and `rack-session` to patched versions for the current `bundle-audit` advisories.
 
 ### Tests
 - Added breadcrumb regression coverage for duplicate Home prevention and breadcrumb link class merging.

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/breadcrumb/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/breadcrumb/component.rb
@@ -94,10 +94,11 @@ module FlatPack
 
         # Add back item if requested
         if @show_back
-          items_list << item(
+          items_list << build_internal_item(
             text: @back_text,
             href: resolved_back_href(breadcrumb_items),
-            icon: @back_icon
+            icon: @back_icon,
+            class: "mr-3"
           )
         end
 
@@ -109,7 +110,7 @@ module FlatPack
 
         # Add home item if requested
         if @show_home
-          items_list << item(
+          items_list << build_internal_item(
             text: @home_text,
             href: @home_url,
             icon: @home_icon
@@ -125,6 +126,10 @@ module FlatPack
 
       def previous_breadcrumb_href(breadcrumb_items)
         breadcrumb_items[0...-1].reverse_each.find(&:href)&.href
+      end
+
+      def build_internal_item(**kwargs)
+        FlatPack::Breadcrumb::Item::Component.new(**kwargs)
       end
 
       def maybe_collapse_items(items_list)

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/breadcrumb/item/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/breadcrumb/item/component.rb
@@ -45,10 +45,17 @@ module FlatPack
         def render_link_item
           link_to(href,
             {
-              class: "flex items-center text-[var(--breadcrumb-link-color)] hover:text-[var(--breadcrumb-link-hover-color)] transition-colors"
-            }.merge(@system_arguments)) do
+              class: link_classes
+            }.merge(@system_arguments.except(:class))) do
             item_content
           end
+        end
+
+        def link_classes
+          [
+            "flex items-center text-[var(--breadcrumb-link-color)] hover:text-[var(--breadcrumb-link-hover-color)] transition-colors",
+            @system_arguments[:class]
+          ].compact.join(" ")
         end
 
         def item_content

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/text_input/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/text_input/component.rb
@@ -102,7 +102,7 @@ module FlatPack
         ]
 
         base_classes << if @error
-          "border-warning"
+          "border-[var(--color-warning)]"
         else
           "border-[var(--surface-border-color)]"
         end
@@ -111,7 +111,7 @@ module FlatPack
       end
 
       def error_classes
-        "mt-1 text-sm text-warning"
+        "mt-1 text-sm text-[var(--color-warning)]"
       end
 
       def input_id

--- a/test/dummy/vendor/flat_pack/app/javascript/flat_pack/controllers/form_validation_controller.js
+++ b/test/dummy/vendor/flat_pack/app/javascript/flat_pack/controllers/form_validation_controller.js
@@ -104,7 +104,7 @@ export default class extends Controller {
     errorNode.classList.remove("hidden")
 
     // Apply a visible invalid border for JS-driven validation states.
-    this.element.classList.add("border-warning")
+    this.element.classList.add("border-[var(--color-warning)]")
     this.element.style.borderColor = "var(--color-warning)"
 
     this.element.setAttribute("aria-invalid", "true")
@@ -118,7 +118,7 @@ export default class extends Controller {
       errorNode.textContent = ""
     }
 
-    this.element.classList.remove("border-warning")
+    this.element.classList.remove("border-[var(--color-warning)]")
     if (this.initialBorderColor) {
       this.element.style.borderColor = this.initialBorderColor
     } else {
@@ -143,7 +143,7 @@ export default class extends Controller {
 
     const node = document.createElement("p")
     node.id = this.errorIdValue
-    node.className = "mt-1 text-sm text-warning hidden"
+    node.className = "mt-1 text-sm text-[var(--color-warning)] hidden"
 
     const container = this.errorContainer()
     if (container) {

--- a/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
+++ b/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.57"
+  VERSION = "0.1.58"
 end

--- a/test/javascript/form_validation_controller_test.js
+++ b/test/javascript/form_validation_controller_test.js
@@ -1,0 +1,133 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+function loadController(overrides = {}) {
+  const filePath = path.join(__dirname, '..', '..', 'app', 'javascript', 'flat_pack', 'controllers', 'form_validation_controller.js')
+  const source = fs.readFileSync(filePath, 'utf8')
+  const transformedSource = source
+    .replace('import { Controller } from "@hotwired/stimulus"', 'class Controller {}')
+    .replace('export default class extends Controller', 'class FormValidationController extends Controller') + '\nmodule.exports = FormValidationController\n'
+
+  const context = {
+    module: { exports: {} },
+    exports: {},
+    ...overrides
+  }
+
+  vm.runInNewContext(transformedSource, context, { filename: filePath })
+
+  return context.module.exports
+}
+
+function buildController() {
+  const HTMLElementClass = class {}
+  const nodeClasses = new Set(["hidden"])
+  let errorClassName = ""
+  let createdErrorNode = null
+  const errorNode = {
+    id: "username_error",
+    textContent: "",
+    get className() {
+      return errorClassName
+    },
+    set className(value) {
+      errorClassName = value
+    },
+    classList: {
+      add(...tokens) {
+        tokens.forEach((token) => nodeClasses.add(token))
+      },
+      remove(...tokens) {
+        tokens.forEach((token) => nodeClasses.delete(token))
+      }
+    }
+  }
+
+  const parentElement = {
+    appendedNode: null,
+    appendChild(node) {
+      this.appendedNode = node
+    }
+  }
+
+  const element = new HTMLElementClass()
+  Object.assign(element, {
+    type: "text",
+    required: true,
+    value: "",
+    style: { borderColor: "" },
+    dataset: {},
+    attributes: { "aria-describedby": "help-text" },
+    classList: {
+      classes: new Set(),
+      add(...tokens) {
+        tokens.forEach((token) => this.classes.add(token))
+      },
+      remove(...tokens) {
+        tokens.forEach((token) => this.classes.delete(token))
+      }
+    },
+    parentElement,
+    getAttribute(name) {
+      return this.attributes[name] || null
+    },
+    setAttribute(name, value) {
+      this.attributes[name] = value
+    },
+    removeAttribute(name) {
+      delete this.attributes[name]
+    }
+  })
+
+  const document = {
+    createElement(tagName) {
+      assert.equal(tagName, "p")
+      createdErrorNode = errorNode
+      return errorNode
+    },
+    getElementById(id) {
+      return id === "username_error" ? createdErrorNode : null
+    }
+  }
+
+  const FormValidationController = loadController({ document, HTMLElement: HTMLElementClass })
+  const controller = new FormValidationController()
+  controller.element = element
+  controller.initialDescribedBy = "help-text"
+  controller.initialBorderColor = "rgb(1, 2, 3)"
+  controller.hasErrorIdValue = true
+  controller.errorIdValue = "username_error"
+
+  return { controller, element, errorNode, nodeClasses, document }
+}
+
+test('showError uses the semantic warning token classes', () => {
+  const { controller, element, errorNode, nodeClasses, document } = buildController()
+
+  controller.showError('Username is invalid')
+
+  assert.equal(element.classList.classes.has('border-[var(--color-warning)]'), true)
+  assert.equal(element.style.borderColor, 'var(--color-warning)')
+  assert.equal(element.attributes['aria-invalid'], 'true')
+  assert.equal(element.attributes['aria-describedby'], 'help-text username_error')
+  assert.equal(errorNode.textContent, 'Username is invalid')
+  assert.equal(errorNode.className, 'mt-1 text-sm text-[var(--color-warning)] hidden')
+  assert.equal(nodeClasses.has('hidden'), false)
+})
+
+test('clearError removes the semantic warning token classes', () => {
+  const { controller, element, errorNode, nodeClasses, document } = buildController()
+
+  controller.showError('Username is invalid')
+  controller.clearError()
+
+  assert.equal(element.classList.classes.has('border-[var(--color-warning)]'), false)
+  assert.equal(element.style.borderColor, 'rgb(1, 2, 3)')
+  assert.equal(element.attributes['aria-invalid'], undefined)
+  assert.equal(element.attributes['aria-describedby'], 'help-text')
+  assert.equal(errorNode.textContent, '')
+  assert.equal(nodeClasses.has('hidden'), true)
+})


### PR DESCRIPTION
Correct breadcrumb rendering to ensure the Home link appears only once and maintain consistent spacing for the Back link. Update warning states to utilize semantic token classes. Bump the version to 0.1.58.