### PR TITLE
Restore ViewComponent slot compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated the locked `net-imap` and `view_component` dependencies to patched versions so `bundle-audit` no longer reports the published advisories.
 
+## [0.1.60] - 2026-05-15
+
+### Fixed
+- Restored FlatPack slot helper compatibility on ViewComponent 4.x so table and other slot-backed components render correctly in the dummy app and engine tests.
+
 ## [0.1.59] - 2026-05-15
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.59)
+    flat_pack (0.1.60)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -411,7 +411,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.59)
+  flat_pack (0.1.60)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -6,7 +6,7 @@ This document summarizes the current FlatPack repository layout and the files th
 
 **FlatPack** is a Rails engine that ships ViewComponent-based UI components, Tailwind CSS 4 token styling, Propshaft-served assets, and importmap-friendly JavaScript.
 
-**Version:** 0.1.59
+**Version:** 0.1.60
 **License:** MIT  
 **Ruby:** 3.2+  
 **Supported host apps:** Rails 7.1+  

--- a/app/components/flat_pack/base_component.rb
+++ b/app/components/flat_pack/base_component.rb
@@ -10,6 +10,18 @@ module FlatPack
 
     private
 
+    def set_slot(slot_name, slot_definition = nil, *args, **kwargs, &block)
+      __vc_set_slot(slot_name, slot_definition, *args, **kwargs, &block)
+    end
+
+    def get_slot(slot_name)
+      __vc_get_slot(slot_name)
+    end
+
+    def set_polymorphic_slot(slot_name, poly_type = nil, *args, **kwargs, &block)
+      __vc_set_polymorphic_slot(slot_name, poly_type, *args, **kwargs, &block)
+    end
+
     # Extract and merge classes using tailwind_merge
     def classes(*additional_classes)
       base_classes = @system_arguments.delete(:class) || ""

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -3,7 +3,7 @@
   "updated_at": "2026-05-15",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.59"
+    "version": "0.1.60"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This document provides the exact terminal commands and configuration steps neede
 
 FlatPack is a modern Rails UI Component Library built with ViewComponent, Tailwind CSS, and Hotwire. It provides type-safe, testable components with dark mode support and accessibility features. Supports Rails 7.1 and above.
 
-**Current Version:** 0.1.59 (Updated May 15, 2026)
+**Current Version:** 0.1.60 (Updated May 15, 2026)
 
 ## AI-first installation entrypoint
 

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.59"
+  VERSION = "0.1.60"
 end

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.59)
+    flat_pack (0.1.60)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -312,7 +312,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.59)
+  flat_pack (0.1.60)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.app_platform.lock
+++ b/test/dummy/Gemfile.app_platform.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.59)
+    flat_pack (0.1.60)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -370,7 +370,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.59)
+  flat_pack (0.1.60)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.59)
+    flat_pack (0.1.60)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Updated the locked `net-imap` and `view_component` dependencies to patched versions so `bundle-audit` no longer reports the published advisories.
 
+## [0.1.60] - 2026-05-15
+
+### Fixed
+- Restored FlatPack slot helper compatibility on ViewComponent 4.x so table and other slot-backed components render correctly in the dummy app and engine tests.
+
 ## [0.1.59] - 2026-05-15
 
 ### Fixed

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/base_component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/base_component.rb
@@ -10,6 +10,18 @@ module FlatPack
 
     private
 
+    def set_slot(slot_name, slot_definition = nil, *args, **kwargs, &block)
+      __vc_set_slot(slot_name, slot_definition, *args, **kwargs, &block)
+    end
+
+    def get_slot(slot_name)
+      __vc_get_slot(slot_name)
+    end
+
+    def set_polymorphic_slot(slot_name, poly_type = nil, *args, **kwargs, &block)
+      __vc_set_polymorphic_slot(slot_name, poly_type, *args, **kwargs, &block)
+    end
+
     # Extract and merge classes using tailwind_merge
     def classes(*additional_classes)
       base_classes = @system_arguments.delete(:class) || ""

--- a/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
+++ b/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.59"
+  VERSION = "0.1.60"
 end


### PR DESCRIPTION
## Summary
Restore FlatPack slot helper compatibility on ViewComponent 4.x so slot-backed components render correctly again.

## What changed
- add `set_slot`, `get_slot`, and `set_polymorphic_slot` compatibility wrappers to the shared base component
- mirror the same fix into the deployable dummy app snapshot
- bump FlatPack version metadata and changelog entries to `0.1.60`

## Validation
- `bundle exec ruby -Itest test/components/flat_pack/table_component_test.rb`
- `cd test/dummy && bundle exec rails runner "require 'ostruct'; html = ApplicationController.render(inline: %q{<%= render FlatPack::Table::Component.new(data: [OpenStruct.new(name: 'Alice')]) do |table| %><% table.column(title: 'Name') { |row| row.name } %><% end %>}); puts html.include?('Alice')"`

## Notes
`bundle exec rubocop -A` is currently blocked in this environment because `rubocop-discourse` is not installed.