### PR TITLE
Rename slot APIs and update documentation for version 0.1.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.74] - 2026-06-04
+
+### Changed
+- Updated dummy page copy for slot-based APIs so component demo headings/subtitles now consistently say "slots" instead of "actions" where applicable.
+- Added `--comments-composer-slots-background-color` as a new token alias backed by `--comments-composer-actions-background-color` to keep theming backward compatible during slot naming migration.
+
 ## [0.1.73] - 2026-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.73] - 2026-06-04
+
+### Changed
+- Updated `FlatPack::Chart::Component` to prefer `top_right_slot` over `actions` for header action content while keeping `actions` as a deprecated compatibility alias.
+- Updated `FlatPack::PageTitle::Component`, `FlatPack::EmptyState::Component`, `FlatPack::Hero::Component`, and `FlatPack::Comments::Composer::Component` to prefer `slot` over `actions` while keeping `actions` as a deprecated compatibility alias.
+- Updated component docs and dummy app examples to use the new preferred slot method names and document the deprecated aliases.
+
 ## [0.1.72] - 2026-06-04
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.73)
+    flat_pack (0.1.74)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -446,7 +446,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.73)
+  flat_pack (0.1.74)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.72)
+    flat_pack (0.1.73)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -446,7 +446,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.72)
+  flat_pack (0.1.73)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/app/assets/stylesheets/flat_pack/variables.css
+++ b/app/assets/stylesheets/flat_pack/variables.css
@@ -284,6 +284,7 @@
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -769,6 +770,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -1091,6 +1093,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -1548,6 +1551,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -2005,6 +2009,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);

--- a/app/components/flat_pack/base_component.rb
+++ b/app/components/flat_pack/base_component.rb
@@ -22,6 +22,12 @@ module FlatPack
       __vc_set_polymorphic_slot(slot_name, poly_type, *args, **kwargs, &block)
     end
 
+    def warn_deprecated_api(old_name, new_name)
+      ActiveSupport::Deprecation._instance.warn(
+        "#{self.class.name}##{old_name} is deprecated and will be removed in a future release. Use ##{new_name} instead."
+      )
+    end
+
     # Extract and merge classes using tailwind_merge
     def classes(*additional_classes)
       base_classes = @system_arguments.delete(:class) || ""

--- a/app/components/flat_pack/chart/component.rb
+++ b/app/components/flat_pack/chart/component.rb
@@ -53,10 +53,15 @@ module FlatPack
         end
       end
 
-      def actions(*args, **kwargs, &block)
+      def top_right_slot(*args, **kwargs, &block)
         return actions_slot if args.empty? && kwargs.empty? && !block_given?
 
         set_slot(:actions, nil, *args, **kwargs, &block)
+      end
+
+      def actions(*args, **kwargs, &block)
+        warn_deprecated_api(:actions, :top_right_slot)
+        top_right_slot(*args, **kwargs, &block)
       end
 
       def footer(*args, **kwargs, &block)
@@ -106,7 +111,7 @@ module FlatPack
       def render_actions_section
         return nil unless actions?
 
-        content_tag(:div, actions, class: "flex gap-2")
+        content_tag(:div, actions_slot, class: "flex gap-2")
       end
 
       def render_chart_only

--- a/app/components/flat_pack/comments/composer/component.rb
+++ b/app/components/flat_pack/comments/composer/component.rb
@@ -65,10 +65,19 @@ module FlatPack
           set_slot(:attachments, nil, *args, **kwargs, &block)
         end
 
-        def actions(*args, **kwargs, &block)
+        def slot(*args, **kwargs, &block)
           return get_slot(:actions) if args.empty? && kwargs.empty? && !block
 
           set_slot(:actions, nil, *args, **kwargs, &block)
+        end
+
+        def slot?
+          actions?
+        end
+
+        def actions(*args, **kwargs, &block)
+          warn_deprecated_api(:actions, :slot)
+          slot(*args, **kwargs, &block)
         end
 
         private
@@ -136,7 +145,7 @@ module FlatPack
         end
 
         def render_actions_section
-          return content_tag(:div, actions, class: action_section_classes) if actions?
+          return content_tag(:div, slot, class: action_section_classes) if slot?
           return render_default_actions if @show_cancel
 
           nil

--- a/app/components/flat_pack/empty_state/component.rb
+++ b/app/components/flat_pack/empty_state/component.rb
@@ -55,10 +55,19 @@ module FlatPack
         end
       end
 
-      def actions(*args, **kwargs, &block)
+      def slot(*args, **kwargs, &block)
         return actions_slot if args.empty? && kwargs.empty? && !block_given?
 
         set_slot(:actions, nil, *args, **kwargs, &block)
+      end
+
+      def slot?
+        actions?
+      end
+
+      def actions(*args, **kwargs, &block)
+        warn_deprecated_api(:actions, :slot)
+        slot(*args, **kwargs, &block)
       end
 
       def graphic(*args, **kwargs, &block)
@@ -115,9 +124,9 @@ module FlatPack
       end
 
       def render_actions
-        return nil unless actions?
+        return nil unless slot?
 
-        content_tag(:div, actions, class: "flex gap-3 flex-wrap justify-center")
+        content_tag(:div, slot, class: "flex gap-3 flex-wrap justify-center")
       end
 
       def validate_title!

--- a/app/components/flat_pack/hero/component.rb
+++ b/app/components/flat_pack/hero/component.rb
@@ -19,10 +19,19 @@ module FlatPack
       undef_method :with_actions_slot, :with_actions_slot_content
       undef_method :with_badge_slot, :with_badge_slot_content
 
-      def actions(**args, &block)
+      def slot(**args, &block)
         return actions_slot if args.empty? && !block
 
         set_slot(:actions_slot, nil, **args, &block)
+      end
+
+      def slot?
+        actions_slot?
+      end
+
+      def actions(**args, &block)
+        warn_deprecated_api(:actions, :slot)
+        slot(**args, &block)
       end
 
       def badge(**args, &block)
@@ -113,9 +122,9 @@ module FlatPack
       end
 
       def render_actions_block(extra_classes: "")
-        return nil unless actions_slot?
+        return nil unless slot?
 
-        content_tag(:div, actions, class: "mt-10 flex flex-col sm:flex-row gap-4 #{extra_classes}".strip)
+        content_tag(:div, slot, class: "mt-10 flex flex-col sm:flex-row gap-4 #{extra_classes}".strip)
       end
 
       def render_text_block
@@ -177,7 +186,7 @@ module FlatPack
                 render_description
               ].compact)
             end,
-            (content_tag(:div, render_actions_block(extra_classes: "justify-center"), class: "mt-10 flex justify-center") if actions_slot?),
+            (content_tag(:div, render_actions_block(extra_classes: "justify-center"), class: "mt-10 flex justify-center") if slot?),
             (@image_url ? content_tag(:div, class: "mt-16 max-w-5xl mx-auto rounded-xl shadow-2xl overflow-hidden") {
               image_tag(@image_url, alt: @image_alt, class: "w-full object-cover")
             } : nil)

--- a/app/components/flat_pack/page_title/component.rb
+++ b/app/components/flat_pack/page_title/component.rb
@@ -36,10 +36,19 @@ module FlatPack
         content_tag(:div, **container_attributes) { render_header_content }
       end
 
-      def actions(*args, **kwargs, &block)
+      def slot(*args, **kwargs, &block)
         return actions_slot if args.empty? && kwargs.empty? && !block_given?
 
         set_slot(:actions, nil, *args, **kwargs, &block)
+      end
+
+      def slot?
+        actions?
+      end
+
+      def actions(*args, **kwargs, &block)
+        warn_deprecated_api(:actions, :slot)
+        slot(*args, **kwargs, &block)
       end
 
       private
@@ -123,9 +132,9 @@ module FlatPack
       end
 
       def render_actions
-        return nil unless actions?
+        return nil unless slot?
 
-        content_tag(:div, actions, class: "page-title-actions mt-4 flex flex-wrap items-center gap-3")
+        content_tag(:div, slot, class: "page-title-actions mt-4 flex flex-wrap items-center gap-3")
       end
 
       def validate_title!

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -3,7 +3,7 @@
   "updated_at": "2026-06-04",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.73"
+    "version": "0.1.74"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-05-29",
+  "updated_at": "2026-06-04",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.72"
+    "version": "0.1.73"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/components/NEW_COMPONENTS_SUMMARY.md
+++ b/docs/components/NEW_COMPONENTS_SUMMARY.md
@@ -63,7 +63,7 @@ User-friendly empty states with optional icons, overridable icon names, actions,
   description: "Try adjusting your search",
   icon: :search
 ) do |component| %>
-  <% component.actions do %>
+  <% component.slot do %>
     <%= render FlatPack::Button::Component.new(text: "Clear filters") %>
   <% end %>
 <% end %>

--- a/docs/components/charts.md
+++ b/docs/components/charts.md
@@ -26,7 +26,7 @@ Use `FlatPack::ChartButtons::Component` as a sibling when you need reusable Turb
 ## Slots
 | Slot | Description |
 | --- | --- |
-| `actions` | Header action area (for buttons, filters, menus) when `card: true`. |
+| `top_right_slot` | Header action area (for buttons, filters, menus) when `card: true`. |
 | `footer` | Card footer content when `card: true`. |
 
 ## Variants
@@ -60,7 +60,7 @@ Use `FlatPack::ChartButtons::Component` as a sibling when you need reusable Turb
   title: "Financial Overview",
   subtitle: "Last 7 months"
 ) do |chart| %>
-  <% chart.actions do %>
+  <% chart.top_right_slot do %>
     <%= render FlatPack::Button::Component.new(text: "Export", size: :sm, style: :ghost) %>
   <% end %>
 <% end %>

--- a/docs/components/comments-composer.md
+++ b/docs/components/comments-composer.md
@@ -1,10 +1,10 @@
 # Comments Composer
 
 ## Purpose
-Render a comment entry surface with plain-text or rich-text input, optional custom toolbar/attachments slots, and submit actions.
+Render a comment entry surface with plain-text or rich-text input, optional custom toolbar/attachments slots, and submit controls.
 
 ## When to use
-Use Comments Composer where users create or edit comments with optional custom actions.
+Use Comments Composer where users create or edit comments with optional custom slot content.
 
 The default composer uses a rounded-xl textarea shell and a floating send control.
 Enable `rich_text: true` when the comment flow needs TipTap formatting controls such as the standard toolbar or selection bubble menu.
@@ -16,7 +16,7 @@ Enable `rich_text: true` when the comment flow needs TipTap formatting controls 
 | name | type | default | required | description |
 |---|---|---|---|---|
 | `placeholder` | String | `"Write a comment..."` | no | Textarea placeholder text. |
-| `submit_label` | String | `"Comment"` | no | Default submit button label when custom `actions` slot is not provided. |
+| `submit_label` | String | `"Comment"` | no | Default submit button label when custom `slot` content is not provided. |
 | `cancel_label` | String | `"Cancel"` | no | Default cancel button label when `show_cancel` is true. |
 | `show_cancel` | Boolean | `false` | no | Shows cancel button in default actions row. |
 | `disabled` | Boolean | `false` | no | Disables textarea and default actions and applies muted state. |
@@ -33,11 +33,11 @@ Enable `rich_text: true` when the comment flow needs TipTap formatting controls 
 ## Slots
 - `toolbar`: optional custom slot rendered below the input shell and above attachments/actions. This is separate from the TipTap rich-text toolbar controlled by `rich_text_options[:toolbar]`.
 - `attachments`: optional region for file chips/previews.
-- `actions`: custom actions row; overrides default cancel/submit controls.
+- `slot`: custom controls row; overrides default cancel/submit controls.
 
 ## Variants
 - Density variant via `compact: true/false`.
-- Action mode via default actions or custom `actions` slot.
+- Control mode via default actions or custom `slot` content.
 - Input mode via plain textarea (`rich_text: false`) or TipTap-backed rich text (`rich_text: true`).
 
 ## Example

--- a/docs/components/comments-thread.md
+++ b/docs/components/comments-thread.md
@@ -28,9 +28,8 @@ Use Comments Thread as the root wrapper for page-level comment sections.
 
 ## Variants
 - Spacing variants: `:default`, `:compact`.
-- Interaction mode: unlocked or locked (`locked: true`).
+ 
 
-## Example
 ```erb
 <%= render FlatPack::Comments::Thread::Component.new(count: @comments.count, title: "Discussion") do |thread| %>
   <% thread.composer do %>
@@ -137,7 +136,7 @@ https://redesigned-doodle-7vv56g46g9fp6qr-3000.app.github.dev/demo/comments?repl
                 compact: true,
                 rows: 2
               ) do |composer| %>
-                <% composer.actions do %>
+                <% composer.slot do %>
                   <div class="flex items-center justify-end w-full gap-2">
                     <%= render FlatPack::Button::Component.new(
                       text: "Cancel",

--- a/docs/components/empty-state.md
+++ b/docs/components/empty-state.md
@@ -21,7 +21,7 @@ Use Empty State when a list, search, inbox, or dashboard panel has no content ye
 | name | type | required | description |
 |---|---|---|---|
 | `graphic` | slot | no | Replaces built-in icon area with custom graphic content. |
-| `actions` | slot | no | Action row (buttons/links). |
+| `slot` | slot | no | Action row (buttons/links). |
 
 ## Variants
 None.
@@ -33,7 +33,7 @@ None.
   description: "Try a different filter or keyword.",
   icon: :search
 ) do |state| %>
-  <% state.actions do %>
+  <% state.slot do %>
     <%= render FlatPack::Button::Component.new(text: "Clear filters") %>
   <% end %>
 <% end %>

--- a/docs/components/hero.md
+++ b/docs/components/hero.md
@@ -35,7 +35,7 @@ Do not use for smaller in-page promotional banners; use `FlatPack::Alert::Compon
 
 | name | required | description |
 |---|---|---|
-| `actions` | no | CTA button area rendered below the description in all variants. Use `concat render(...)` for multiple buttons. |
+| `slot` | no | CTA button area rendered below the description in all variants. Use `concat render(...)` for multiple buttons. |
 | `badge` | no | Optional badge or pill rendered above the tagline. |
 
 Both slots follow the no-`with_` prefix convention. Set via block:
@@ -43,7 +43,7 @@ Both slots follow the no-`with_` prefix convention. Set via block:
 ```erb
 <%= render FlatPack::Hero::Component.new(variant: :centered, headline: "Hello") do |hero|
   hero.badge { render FlatPack::Badge::Component.new(label: "New") }
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(label: "Start", href: "#"))
   end
 end %>
@@ -70,7 +70,7 @@ end %>
   headline: "Build beautiful interfaces faster.",
   description: "A Rails ViewComponent library with Tailwind CSS."
 ) do |hero|
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(label: "Get started", variant: :primary, href: "/docs"))
     concat render(FlatPack::Button::Component.new(label: "Learn more", variant: :outline, href: "/about"))
   end
@@ -89,7 +89,7 @@ end %>
   image_alt: "Product screenshot"
 ) do |hero|
   hero.badge { render FlatPack::Badge::Component.new(label: "v2.0") }
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(label: "View docs", href: "/docs"))
   end
 end %>
@@ -115,7 +115,7 @@ end %>
 - Use a single `<h1>` per page; the hero headline fills that semantic role.
 - Pass `image_alt: ""` for purely decorative images. This renders an empty `alt` attribute, which instructs screen readers to skip the image.
 - The background image in `centered_image` is applied via CSS (`background-image` inline style) and carries no `alt` text, making it presentational by default.
-- Buttons and links inside the `actions` slot must have descriptive labels. Avoid generic labels like "Click here".
+- Buttons and links inside the `slot` area must have descriptive labels. Avoid generic labels like "Click here".
 - Ensure sufficient colour contrast between overlay text and the background for `centered_image`. The built-in `bg-black/60` overlay meets WCAG AA for white text in most cases, but verify with your specific image.
 
 ## Dependencies

--- a/docs/components/page-title.md
+++ b/docs/components/page-title.md
@@ -23,7 +23,7 @@ Use Page Title for page-level headings when you do not want the bordered visual 
 ## Slots
 | name | type | description |
 |---|---|---|
-| `actions` | Block | Optional action content rendered directly below the subtitle, or directly below the title when no subtitle is present. |
+| `slot` | Block | Optional action content rendered directly below the subtitle, or directly below the title when no subtitle is present. |
 
 ## Variants
 - Heading level variants: `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6`
@@ -38,15 +38,15 @@ Use Page Title for page-level headings when you do not want the bordered visual 
   title_color: "var(--color-primary)",
   subtitle_color: "oklch(0.35 0.02 250)"
 ) do |page_title| %>
-  <% page_title.actions do %>
+  <% page_title.slot do %>
     <%= render FlatPack::Button::Component.new(text: "Invite member", style: :secondary, size: :sm) %>
   <% end %>
 <% end %>
 ```
 
 ## Behavior
-- `actions` renders immediately below the subtitle when `subtitle` is present.
-- `actions` renders immediately below the title when `subtitle` is omitted.
+- `slot` renders immediately below the subtitle when `subtitle` is present.
+- `slot` renders immediately below the title when `subtitle` is omitted.
 
 ## Accessibility
 - Uses semantic heading tags via `variant` (`h1`-`h6`).

--- a/docs/custom_theming.md
+++ b/docs/custom_theming.md
@@ -311,6 +311,7 @@ This block mirrors the current default light palette from `app/assets/stylesheet
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.72"
+  VERSION = "0.1.73"
 end

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.73"
+  VERSION = "0.1.74"
 end

--- a/test/components/flat_pack/chart/component_test.rb
+++ b/test/components/flat_pack/chart/component_test.rb
@@ -144,13 +144,26 @@ module FlatPack
         assert_selector "p", text: "Monthly data"
       end
 
-      def test_renders_chart_with_actions
+      def test_renders_chart_with_top_right_slot
         series = [{name: "Sales", data: [10, 20, 30]}]
         render_inline(Component.new(series: series)) do |component|
-          component.actions { "Export" }
+          component.top_right_slot { "Export" }
         end
 
         assert_selector "div", text: "Export"
+      end
+
+      def test_actions_is_deprecated_in_favor_of_top_right_slot
+        series = [{name: "Sales", data: [10, 20, 30]}]
+
+        _stdout, stderr = capture_io do
+          render_inline(Component.new(series: series)) do |component|
+            component.actions { "Export" }
+          end
+        end
+
+        assert_includes stderr, "FlatPack::Chart::Component#actions is deprecated"
+        assert_includes stderr, "#top_right_slot"
       end
 
       def test_renders_chart_with_footer

--- a/test/components/flat_pack/comments_composer_component_test.rb
+++ b/test/components/flat_pack/comments_composer_component_test.rb
@@ -195,12 +195,23 @@ module FlatPack
           assert_text "Attachments"
         end
 
-        def test_renders_custom_actions_slot
+        def test_renders_custom_slot
           component = Component.new
-          component.actions { "Custom Actions" }
+          component.slot { "Custom Actions" }
           render_inline(component)
 
           assert_text "Custom Actions"
+        end
+
+        def test_actions_is_deprecated_in_favor_of_slot
+          _stdout, stderr = capture_io do
+            component = Component.new
+            component.actions { "Custom Actions" }
+            render_inline(component)
+          end
+
+          assert_includes stderr, "FlatPack::Comments::Composer::Component#actions is deprecated"
+          assert_includes stderr, "#slot"
         end
 
         def test_does_not_expose_with_slot_aliases

--- a/test/components/flat_pack/empty_state/component_test.rb
+++ b/test/components/flat_pack/empty_state/component_test.rb
@@ -51,14 +51,25 @@ module FlatPack
         assert_selector "svg[data-flat-pack--icon-name-value='arrow-up-tray']"
       end
 
-      def test_renders_actions_slot
+      def test_renders_slot
         render_inline(Component.new(title: "Empty")) do |component|
-          component.actions do
+          component.slot do
             "Action buttons"
           end
         end
 
         assert_text "Action buttons"
+      end
+
+      def test_actions_is_deprecated_in_favor_of_slot
+        _stdout, stderr = capture_io do
+          render_inline(Component.new(title: "Empty")) do |component|
+            component.actions { "Action buttons" }
+          end
+        end
+
+        assert_includes stderr, "FlatPack::EmptyState::Component#actions is deprecated"
+        assert_includes stderr, "#slot"
       end
 
       def test_renders_custom_graphic_slot

--- a/test/components/flat_pack/hero_component_test.rb
+++ b/test/components/flat_pack/hero_component_test.rb
@@ -91,12 +91,23 @@ module FlatPack
       end
 
       # 8. actions slot content appears in output
-      def test_renders_actions_slot_content
+      def test_renders_slot_content
         render_inline(Component.new(variant: :centered, headline: "CTA")) do |c|
-          c.actions { "Get started now" }
+          c.slot { "Get started now" }
         end
 
         assert_text "Get started now"
+      end
+
+      def test_actions_is_deprecated_in_favor_of_slot
+        _stdout, stderr = capture_io do
+          render_inline(Component.new(variant: :centered, headline: "CTA")) do |c|
+            c.actions { "Get started now" }
+          end
+        end
+
+        assert_includes stderr, "FlatPack::Hero::Component#actions is deprecated"
+        assert_includes stderr, "#slot"
       end
 
       # 9. badge slot content appears in output

--- a/test/components/flat_pack/page_title/component_test.rb
+++ b/test/components/flat_pack/page_title/component_test.rb
@@ -69,9 +69,9 @@ module FlatPack
         assert_selector "p[style*='color: var(--color-primary)']", text: "Welcome back"
       end
 
-      def test_renders_actions_slot_below_subtitle
+      def test_renders_slot_below_subtitle
         render_inline(Component.new(title: "Dashboard", subtitle: "Welcome back")) do |component|
-          component.actions do
+          component.slot do
             "Filter"
           end
         end
@@ -79,14 +79,25 @@ module FlatPack
         assert_selector "p + div.page-title-actions", text: "Filter"
       end
 
-      def test_renders_actions_slot_below_title_when_subtitle_missing
+      def test_renders_slot_below_title_when_subtitle_missing
         render_inline(Component.new(title: "Dashboard")) do |component|
-          component.actions do
+          component.slot do
             "Filter"
           end
         end
 
         assert_selector "h1 + div.page-title-actions", text: "Filter"
+      end
+
+      def test_actions_is_deprecated_in_favor_of_slot
+        _stdout, stderr = capture_io do
+          render_inline(Component.new(title: "Dashboard")) do |component|
+            component.actions { "Filter" }
+          end
+        end
+
+        assert_includes stderr, "FlatPack::PageTitle::Component#actions is deprecated"
+        assert_includes stderr, "#slot"
       end
 
       def test_raises_error_for_invalid_variant

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.72)
+    flat_pack (0.1.73)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -312,7 +312,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.72)
+  flat_pack (0.1.73)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.73)
+    flat_pack (0.1.74)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -312,7 +312,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.73)
+  flat_pack (0.1.74)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.app_platform.lock
+++ b/test/dummy/Gemfile.app_platform.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.73)
+    flat_pack (0.1.74)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -370,7 +370,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.73)
+  flat_pack (0.1.74)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.app_platform.lock
+++ b/test/dummy/Gemfile.app_platform.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.71)
+    flat_pack (0.1.73)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -370,7 +370,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.71)
+  flat_pack (0.1.73)
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.72)
+    flat_pack (0.1.73)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.73)
+    flat_pack (0.1.74)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)

--- a/test/dummy/app/assets/builds/application.css
+++ b/test/dummy/app/assets/builds/application.css
@@ -333,9 +333,6 @@
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
-  .top-1 {
-    top: calc(var(--spacing) * 1);
-  }
   .top-1\/2 {
     top: calc(1 / 2 * 100%);
   }
@@ -772,14 +769,8 @@
   .min-h-screen {
     min-height: 100vh;
   }
-  .w-0 {
-    width: calc(var(--spacing) * 0);
-  }
   .w-0\.5 {
     width: calc(var(--spacing) * 0.5);
-  }
-  .w-1 {
-    width: calc(var(--spacing) * 1);
   }
   .w-1\.5 {
     width: calc(var(--spacing) * 1.5);
@@ -961,17 +952,11 @@
   .min-w-\[300px\] {
     min-width: 300px;
   }
-  .min-w-full {
-    min-width: 100%;
-  }
   .flex-1 {
     flex: 1;
   }
   .flex-none {
     flex: none;
-  }
-  .flex-shrink {
-    flex-shrink: 1;
   }
   .flex-shrink-0 {
     flex-shrink: 0;
@@ -981,9 +966,6 @@
   }
   .shrink-0 {
     flex-shrink: 0;
-  }
-  .basis-1 {
-    flex-basis: calc(var(--spacing) * 1);
   }
   .basis-1\/3 {
     flex-basis: calc(1 / 3 * 100%);
@@ -995,10 +977,6 @@
     --tw-translate-x: -100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
-  .translate-x-1 {
-    --tw-translate-x: calc(var(--spacing) * 1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
   .translate-x-1\/4 {
     --tw-translate-x: calc(1 / 4 * 100%);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -1007,20 +985,12 @@
     --tw-translate-x: 100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
-  .-translate-y-1 {
-    --tw-translate-y: calc(var(--spacing) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
   .-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/4 {
     --tw-translate-y: calc(calc(1 / 4 * 100%) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  .translate-y-0 {
-    --tw-translate-y: calc(var(--spacing) * 0);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .translate-y-0\.5 {
@@ -1216,13 +1186,6 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(var(--stack-gap-md) * var(--tw-space-y-reverse));
       margin-block-end: calc(var(--stack-gap-md) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
-  .space-y-0 {
-    :where(& > :not(:last-child)) {
-      --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-0\.5 {
@@ -2666,9 +2629,6 @@
   .text-pretty {
     text-wrap: pretty;
   }
-  .text-wrap {
-    text-wrap: wrap;
-  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -3232,9 +3192,6 @@
   .ring-\[var\(--color-ring\)\] {
     --tw-ring-color: var(--color-ring);
   }
-  .ring-black {
-    --tw-ring-color: var(--color-black);
-  }
   .ring-black\/5 {
     --tw-ring-color: color-mix(in srgb, #000 5%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3259,9 +3216,6 @@
   .outline {
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
-  }
-  .outline-black {
-    outline-color: var(--color-black);
   }
   .outline-black\/5 {
     outline-color: color-mix(in srgb, #000 5%, transparent);
@@ -3292,10 +3246,6 @@
   }
   .backdrop-blur-sm {
     --tw-backdrop-blur: blur(var(--blur-sm));
-    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-  }
-  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }

--- a/test/dummy/app/assets/builds/application.css
+++ b/test/dummy/app/assets/builds/application.css
@@ -333,6 +333,9 @@
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
+  .top-1 {
+    top: calc(var(--spacing) * 1);
+  }
   .top-1\/2 {
     top: calc(1 / 2 * 100%);
   }
@@ -769,8 +772,14 @@
   .min-h-screen {
     min-height: 100vh;
   }
+  .w-0 {
+    width: calc(var(--spacing) * 0);
+  }
   .w-0\.5 {
     width: calc(var(--spacing) * 0.5);
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
   }
   .w-1\.5 {
     width: calc(var(--spacing) * 1.5);
@@ -952,11 +961,17 @@
   .min-w-\[300px\] {
     min-width: 300px;
   }
+  .min-w-full {
+    min-width: 100%;
+  }
   .flex-1 {
     flex: 1;
   }
   .flex-none {
     flex: none;
+  }
+  .flex-shrink {
+    flex-shrink: 1;
   }
   .flex-shrink-0 {
     flex-shrink: 0;
@@ -966,6 +981,9 @@
   }
   .shrink-0 {
     flex-shrink: 0;
+  }
+  .basis-1 {
+    flex-basis: calc(var(--spacing) * 1);
   }
   .basis-1\/3 {
     flex-basis: calc(1 / 3 * 100%);
@@ -977,6 +995,10 @@
     --tw-translate-x: -100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .translate-x-1 {
+    --tw-translate-x: calc(var(--spacing) * 1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .translate-x-1\/4 {
     --tw-translate-x: calc(1 / 4 * 100%);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -985,12 +1007,20 @@
     --tw-translate-x: 100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .-translate-y-1 {
+    --tw-translate-y: calc(var(--spacing) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/4 {
     --tw-translate-y: calc(calc(1 / 4 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-y-0 {
+    --tw-translate-y: calc(var(--spacing) * 0);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .translate-y-0\.5 {
@@ -1186,6 +1216,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(var(--stack-gap-md) * var(--tw-space-y-reverse));
       margin-block-end: calc(var(--stack-gap-md) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-0 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-0\.5 {
@@ -2629,6 +2666,9 @@
   .text-pretty {
     text-wrap: pretty;
   }
+  .text-wrap {
+    text-wrap: wrap;
+  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -3192,6 +3232,9 @@
   .ring-\[var\(--color-ring\)\] {
     --tw-ring-color: var(--color-ring);
   }
+  .ring-black {
+    --tw-ring-color: var(--color-black);
+  }
   .ring-black\/5 {
     --tw-ring-color: color-mix(in srgb, #000 5%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -3216,6 +3259,9 @@
   .outline {
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
+  }
+  .outline-black {
+    outline-color: var(--color-black);
   }
   .outline-black\/5 {
     outline-color: color-mix(in srgb, #000 5%, transparent);
@@ -3246,6 +3292,10 @@
   }
   .backdrop-blur-sm {
     --tw-backdrop-blur: blur(var(--blur-sm));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }

--- a/test/dummy/app/views/pages/_component_method_variables_table.html.erb
+++ b/test/dummy/app/views/pages/_component_method_variables_table.html.erb
@@ -393,7 +393,7 @@
         { variable: "name", accepts: "String", example: "name: \"comment[body]\"" },
         { variable: "value", accepts: "String or nil", example: "value: \"Draft comment\"" },
         { variable: "rows", accepts: "Integer", example: "rows: 2" },
-        { variable: "toolbar / attachments / actions", accepts: "slot block", example: "composer.actions { ... }" }
+        { variable: "toolbar / attachments / slot", accepts: "slot block", example: "composer.slot { ... }" }
       ]
     },
     comments_inline_input: {
@@ -502,7 +502,7 @@
         { variable: "background_image_url", accepts: "String or nil (sanitized)", example: "background_image_url: \"https://example.com/bg.jpg\"" },
         { variable: "background", accepts: "CSS color, gradient, or nil", example: "background: \"linear-gradient(135deg, #667eea, #764ba2)\"" },
         { variable: "tiles", accepts: "Array of { url:, alt: } hashes (up to 4)", example: "tiles: [{ url: \"https://...\", alt: \"Feature 1\" }]" },
-        { variable: "actions", accepts: "slot block", example: "hero.actions { concat render(FlatPack::Button::Component.new(text: \"Start\", style: :primary, url: \"#\")) }" },
+        { variable: "slot", accepts: "slot block", example: "hero.slot { concat render(FlatPack::Button::Component.new(text: \"Start\", style: :primary, url: \"#\")) }" },
         { variable: "badge", accepts: "slot block", example: "hero.badge { render FlatPack::Badge::Component.new(text: \"New\", style: :success) }" },
         { variable: "**system_arguments", accepts: "Hash", example: "class: \"bg-[var(--surface-page-background-color)]\", id: \"main-hero\"" }
       ]

--- a/test/dummy/app/views/pages/_demo_reply_form.html.erb
+++ b/test/dummy/app/views/pages/_demo_reply_form.html.erb
@@ -7,7 +7,7 @@
         compact: true,
         rows: 2
       ) do |composer| %>
-      <% composer.actions do %>
+      <% composer.slot do %>
         <div class="flex items-center justify-end w-full gap-2">
           <%= render FlatPack::Button::Component.new(
             text: "Cancel",

--- a/test/dummy/app/views/pages/admin.html.erb
+++ b/test/dummy/app/views/pages/admin.html.erb
@@ -11,7 +11,7 @@
   title: "Admin Dashboard",
   subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."
 ) do |page_title| %>
-  <% page_title.actions do %>
+  <% page_title.slot do %>
     <%= render FlatPack::Button::Component.new(text: "Filter", style: :secondary, size: :sm) %>
   <% end %>
 <% end %>

--- a/test/dummy/app/views/pages/charts.html.erb
+++ b/test/dummy/app/views/pages/charts.html.erb
@@ -133,9 +133,9 @@
   ) %>
 </section>
 
-<!-- Chart with Actions -->
+<!-- Chart with Slot -->
 <section class="mb-12">
-  <%= render FlatPack::SectionTitle::Component.new(title: "Chart with Actions", anchor_link: true, subtitle: "Examples for Chart with Actions.") %>
+  <%= render FlatPack::SectionTitle::Component.new(title: "Chart with Slot", anchor_link: true, subtitle: "Examples for Chart with Slot.") %>
   <%= render FlatPack::Chart::Component.new(
     type: :line,
     series: [{name: "Users", data: [10, 25, 42, 68, 95, 130, 178, 220]}],

--- a/test/dummy/app/views/pages/charts.html.erb
+++ b/test/dummy/app/views/pages/charts.html.erb
@@ -143,7 +143,7 @@
     subtitle: "Last 8 months",
     height: 300
   ) do |chart| %>
-    <% chart.actions do %>
+    <% chart.top_right_slot do %>
       <%= render FlatPack::Button::Component.new(text: "Export", style: :ghost, size: :sm) %>
       <%= render FlatPack::Button::Component.new(text: "Share", style: :secondary, size: :sm) %>
     <% end %>
@@ -160,7 +160,7 @@
         subtitle: "Last 8 months",
         height: 300
       ) do |chart| #{erb_tag_close}
-        #{erb_output_open} chart.actions do #{erb_tag_close}
+        #{erb_output_open} chart.top_right_slot do #{erb_tag_close}
           #{erb_output_open} render FlatPack::Button::Component.new(text: "Export", style: :ghost, size: :sm) #{erb_tag_close}
           #{erb_output_open} render FlatPack::Button::Component.new(text: "Share", style: :secondary, size: :sm) #{erb_tag_close}
         #{erb_open} end #{erb_tag_close}

--- a/test/dummy/app/views/pages/comments.html.erb
+++ b/test/dummy/app/views/pages/comments.html.erb
@@ -101,7 +101,7 @@
           compact: true,
           rows: 2
         ) do |composer| %&gt;
-          &lt;% composer.actions do %&gt;
+          &lt;% composer.slot do %&gt;
             &lt;div class="flex items-center justify-end w-full gap-2"&gt;
               &lt;%= render FlatPack::Button::Component.new(
                 text: "Cancel",

--- a/test/dummy/app/views/pages/empty_state.html.erb
+++ b/test/dummy/app/views/pages/empty_state.html.erb
@@ -26,15 +26,15 @@
   ) %>
 </section>
 
-<!-- Empty State with Actions -->
+<!-- Empty State with Slot -->
 <section class="mb-12">
-  <%= render FlatPack::SectionTitle::Component.new(title: "Empty State with Actions", anchor_link: true, subtitle: "Examples for Empty State with Actions.") %>
+  <%= render FlatPack::SectionTitle::Component.new(title: "Empty State with Slot", anchor_link: true, subtitle: "Examples for Empty State with Slot.") %>
   <div class="border border-[var(--surface-border-color)] rounded-lg p-8">
     <%= render FlatPack::EmptyState::Component.new(
       title: "No projects found",
       description: "Get started by creating your first project. Projects help you organize your work."
     ) do |empty| %>
-      <% empty.actions do %>
+      <% empty.slot do %>
         <%= render FlatPack::Button::Component.new(text: "Create Project", style: :primary) %>
         <%= render FlatPack::Button::Component.new(text: "Import Project", style: :secondary) %>
       <% end %>
@@ -47,7 +47,7 @@
         title: "No projects found",
         description: "Get started by creating your first project."
       ) do |empty| %&gt;
-        &lt;% empty.actions do %&gt;
+        &lt;% empty.slot do %&gt;
           &lt;%= render FlatPack::Button::Component.new(text: "Create Project", style: :primary) %&gt;
         &lt;% end %&gt;
       &lt;% end %&gt;
@@ -177,7 +177,7 @@
           <%= render FlatPack::Shared::IconComponent.new(name: :upload, size: :lg, class: "text-blue-600") %>
         </div>
       <% end %>
-      <% empty.actions do %>
+      <% empty.slot do %>
         <%= render FlatPack::Button::Component.new(text: "Upload CSV", style: :primary) %>
         <%= render FlatPack::Button::Component.new(text: "Connect Source", style: :secondary) %>
       <% end %>
@@ -196,7 +196,7 @@
               &lt;%= render FlatPack::Shared::IconComponent.new(name: :upload, size: :lg, class: &quot;text-blue-600&quot;) %&gt;
             &lt;/div&gt;
           &lt;% end %&gt;
-          &lt;% empty.actions do %&gt;
+          &lt;% empty.slot do %&gt;
             &lt;%= render FlatPack::Button::Component.new(text: &quot;Upload CSV&quot;, style: :primary) %&gt;
             &lt;%= render FlatPack::Button::Component.new(text: &quot;Connect Source&quot;, style: :secondary) %&gt;
           &lt;% end %&gt;
@@ -217,7 +217,7 @@
     <%= render FlatPack::List::Item.new(class: "py-0 px-0") do %><strong>Custom Graphics:</strong> Slot for custom illustrations or icons<% end %>
     <%= render FlatPack::List::Item.new(class: "py-0 px-0") do %><strong>Action Buttons:</strong> Add primary and secondary CTAs<% end %>
     <%= render FlatPack::List::Item.new(class: "py-0 px-0") do %><strong>Centered Layout:</strong> Visually balanced and centered<% end %>
-    <%= render FlatPack::List::Item.new(class: "py-0 px-0") do %><strong>Flexible Content:</strong> Title, description, and actions<% end %>
+    <%= render FlatPack::List::Item.new(class: "py-0 px-0") do %><strong>Flexible Content:</strong> Title, description, and slot content<% end %>
     <%= render FlatPack::List::Item.new(class: "py-0 px-0") do %><strong>Responsive:</strong> Adapts to container width<% end %>
   <% end %>
 </section>

--- a/test/dummy/app/views/pages/hero.html.erb
+++ b/test/dummy/app/views/pages/hero.html.erb
@@ -21,7 +21,7 @@
       background: "linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 50%, #f0fdf4 100%)"
     ) do |hero|
       hero.badge { render FlatPack::Badge::Component.new(text: "New", style: :success) }
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "Get started", style: :primary, url: "#"))
         concat render(FlatPack::Button::Component.new(text: "Learn more", style: :secondary, url: "#"))
       end
@@ -38,7 +38,7 @@
           background: "linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 50%, #f0fdf4 100%)"
         ) do |hero|
           hero.badge { render FlatPack::Badge::Component.new(text: "New", style: :success) }
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "Get started", style: :primary, url: "#"))
             concat render(FlatPack::Button::Component.new(text: "Learn more", style: :secondary, url: "#"))
           end
@@ -60,7 +60,7 @@
       description: "Full-bleed background image with a dark overlay keeps text readable at any resolution.",
       background_image_url: "/images/hero-stool.jpg"
     ) do |hero|
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "Start for free", style: :primary, url: "#"))
         concat render(FlatPack::Button::Component.new(text: "Watch demo", style: :secondary, url: "#"))
       end
@@ -76,7 +76,7 @@
           description: "Full-bleed background image with a dark overlay.",
           background_image_url: "https://example.com/hero-bg.jpg"
         ) do |hero|
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "Start for free", style: :primary, url: "#"))
             concat render(FlatPack::Button::Component.new(text: "Watch demo", style: :secondary, url: "#"))
           end
@@ -99,7 +99,7 @@
       image_url: "/images/hero-stool.jpg",
       image_alt: "DIY flat-pack stool"
     ) do |hero|
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "Try it free", style: :primary, url: "#"))
       end
     end %>
@@ -115,7 +115,7 @@
           image_url: "https://example.com/dashboard.png",
           image_alt: "Application dashboard screenshot"
         ) do |hero|
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "Try it free", style: :primary, url: "#"))
           end
         end %&gt;
@@ -139,7 +139,7 @@
       background: "#f8fafc"
     ) do |hero|
       hero.badge { render FlatPack::Badge::Component.new(text: "v2.0") }
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "See the docs", style: :primary, url: "#"))
         concat render(FlatPack::Button::Component.new(text: "View on GitHub", style: :secondary, url: "#"))
       end
@@ -158,7 +158,7 @@
           background: "#f8fafc"
         ) do |hero|
           hero.badge { render FlatPack::Badge::Component.new(text: "v2.0") }
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "See the docs", style: :primary, url: "#"))
             concat render(FlatPack::Button::Component.new(text: "View on GitHub", style: :secondary, url: "#"))
           end
@@ -181,7 +181,7 @@
       image_url: "/images/hero-stool.jpg",
       image_alt: "DIY flat-pack stool"
     ) do |hero|
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "Explore", style: :primary, url: "#"))
       end
     end %>
@@ -197,7 +197,7 @@
           image_url: "https://example.com/hero.jpg",
           image_alt: "Angled hero image"
         ) do |hero|
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "Explore", style: :primary, url: "#"))
           end
         end %&gt;
@@ -224,7 +224,7 @@
         {url: "/images/hero-subscription-box.webp", alt: "Subscription box fulfillment"}
       ]
     ) do |hero|
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "Get started", style: :primary, url: "#"))
         concat render(FlatPack::Button::Component.new(text: "Learn more", style: :secondary, url: "#"))
       end
@@ -246,7 +246,7 @@
             { url: "https://example.com/4.jpg", alt: "Feature four" }
           ]
         ) do |hero|
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "Get started", style: :primary, url: "#"))
             concat render(FlatPack::Button::Component.new(text: "Learn more", style: :secondary, url: "#"))
           end
@@ -270,7 +270,7 @@
       image_alt: "Packhelp packaging",
       background: "linear-gradient(135deg, #fefce8 0%, #fef9c3 50%, #fef08a 100%)"
     ) do |hero|
-      hero.actions do
+      hero.slot do
         concat render(FlatPack::Button::Component.new(text: "Start now", style: :primary, url: "#"))
       end
     end %>
@@ -286,7 +286,7 @@
           image_url: "https://example.com/hero.jpg",
           image_alt: "Offset hero image"
         ) do |hero|
-          hero.actions do
+          hero.slot do
             concat render(FlatPack::Button::Component.new(text: "Start now", style: :primary, url: "#"))
           end
         end %&gt;

--- a/test/dummy/app/views/pages/hero.html.erb
+++ b/test/dummy/app/views/pages/hero.html.erb
@@ -9,7 +9,7 @@
 
   <!-- Centered -->
   <section class="mb-12">
-    <%= render FlatPack::SectionTitle::Component.new(title: "Centered", anchor_link: true, subtitle: "Centered text and actions. Supports background colours and gradients.") %>
+    <%= render FlatPack::SectionTitle::Component.new(title: "Centered", anchor_link: true, subtitle: "Centered text and slots. Supports background colours and gradients.") %>
     <div class="mb-4 flex justify-end">
       <%= render FlatPack::Button::Component.new(text: "View full-page demo", style: :secondary, url: pages_hero_centered_path, target: "_blank") %>
     </div>

--- a/test/dummy/app/views/pages/hero_angled_image.html.erb
+++ b/test/dummy/app/views/pages/hero_angled_image.html.erb
@@ -10,7 +10,7 @@
   image_url: "/images/hero-stool.jpg",
   image_alt: "DIY flat-pack stool"
 ) do |hero|
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "Explore", style: :primary, url: "#"))
   end
 end %>

--- a/test/dummy/app/views/pages/hero_centered.html.erb
+++ b/test/dummy/app/views/pages/hero_centered.html.erb
@@ -10,7 +10,7 @@
   background: "linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 50%, #f0fdf4 100%)"
 ) do |hero|
   hero.badge { render FlatPack::Badge::Component.new(text: "New", style: :success) }
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "Get started", style: :primary, url: "#"))
     concat render(FlatPack::Button::Component.new(text: "Learn more", style: :secondary, url: "#"))
   end

--- a/test/dummy/app/views/pages/hero_centered_image.html.erb
+++ b/test/dummy/app/views/pages/hero_centered_image.html.erb
@@ -9,7 +9,7 @@
   description: "Full-bleed background image with a dark overlay keeps text readable at any resolution.",
   background_image_url: "/images/hero-stool.jpg"
 ) do |hero|
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "Start for free", style: :primary, url: "#"))
     concat render(FlatPack::Button::Component.new(text: "Watch demo", style: :secondary, url: "#"))
   end

--- a/test/dummy/app/views/pages/hero_image_tiles.html.erb
+++ b/test/dummy/app/views/pages/hero_image_tiles.html.erb
@@ -15,7 +15,7 @@
     {url: "/images/hero-subscription-box.webp", alt: "Subscription box fulfillment"}
   ]
 ) do |hero|
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "Get started", style: :primary, url: "#"))
     concat render(FlatPack::Button::Component.new(text: "Learn more", style: :secondary, url: "#"))
   end

--- a/test/dummy/app/views/pages/hero_offset_image.html.erb
+++ b/test/dummy/app/views/pages/hero_offset_image.html.erb
@@ -11,7 +11,7 @@
   image_alt: "Packhelp packaging",
   background: "linear-gradient(135deg, #fefce8 0%, #fef9c3 50%, #fef08a 100%)"
 ) do |hero|
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "Start now", style: :primary, url: "#"))
   end
 end %>

--- a/test/dummy/app/views/pages/hero_screenshot.html.erb
+++ b/test/dummy/app/views/pages/hero_screenshot.html.erb
@@ -10,7 +10,7 @@
   image_url: "/images/hero-stool.jpg",
   image_alt: "DIY flat-pack stool"
 ) do |hero|
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "Try it free", style: :primary, url: "#"))
   end
 end %>

--- a/test/dummy/app/views/pages/hero_split_image.html.erb
+++ b/test/dummy/app/views/pages/hero_split_image.html.erb
@@ -12,7 +12,7 @@
   background: "#f8fafc"
 ) do |hero|
   hero.badge { render FlatPack::Badge::Component.new(text: "v2.0") }
-  hero.actions do
+  hero.slot do
     concat render(FlatPack::Button::Component.new(text: "See the docs", style: :primary, url: "#"))
     concat render(FlatPack::Button::Component.new(text: "View on GitHub", style: :secondary, url: "#"))
   end

--- a/test/dummy/app/views/pages/page_header.html.erb
+++ b/test/dummy/app/views/pages/page_header.html.erb
@@ -250,7 +250,7 @@
     title: "Admin Dashboard",
     subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."
   ) do |page_title| %>
-    <% page_title.actions do %>
+    <% page_title.slot do %>
       <%= render FlatPack::Button::Component.new(text: "Filter", style: :secondary, size: :sm) %>
       <%= render FlatPack::Button::Component.new(text: "Export", style: :ghost, size: :sm) %>
     <% end %>
@@ -264,7 +264,7 @@
         title: "Admin Dashboard",
         subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."
       ) do |page_title| #{erb_tag_close}
-        #{erb_output_open} page_title.actions do #{erb_tag_close}
+        #{erb_output_open} page_title.slot do #{erb_tag_close}
           #{erb_output_open} render FlatPack::Button::Component.new(text: "Filter", style: :secondary, size: :sm) #{erb_tag_close}
           #{erb_output_open} render FlatPack::Button::Component.new(text: "Export", style: :ghost, size: :sm) #{erb_tag_close}
         #{erb_output_open} end #{erb_tag_close}

--- a/test/dummy/app/views/pages/page_header.html.erb
+++ b/test/dummy/app/views/pages/page_header.html.erb
@@ -243,9 +243,9 @@
   ) %>
 </section>
 
-<!-- Page Title with Actions -->
+<!-- Page Title with Slots -->
 <section class="mb-12">
-  <%= render FlatPack::SectionTitle::Component.new(title: "Page Title with Actions", anchor_link: true, subtitle: "Examples for Page Title with Actions.") %>
+  <%= render FlatPack::SectionTitle::Component.new(title: "Page Title with Slots", anchor_link: true, subtitle: "Examples for Page Title with Slots.") %>
   <%= render FlatPack::PageTitle::Component.new(
     title: "Admin Dashboard",
     subtitle: "Monitor key metrics, track user activity, and manage your workspace from one place."

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.74] - 2026-06-04
+
+### Changed
+- Updated dummy page copy for slot-based APIs so component demo headings/subtitles now consistently say "slots" instead of "actions" where applicable.
+- Added `--comments-composer-slots-background-color` as a new token alias backed by `--comments-composer-actions-background-color` to keep theming backward compatible during slot naming migration.
+
 ## [0.1.73] - 2026-06-04
 
 ### Changed

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.73] - 2026-06-04
+
+### Changed
+- Updated `FlatPack::Chart::Component` to prefer `top_right_slot` over `actions` for header action content while keeping `actions` as a deprecated compatibility alias.
+- Updated `FlatPack::PageTitle::Component`, `FlatPack::EmptyState::Component`, `FlatPack::Hero::Component`, and `FlatPack::Comments::Composer::Component` to prefer `slot` over `actions` while keeping `actions` as a deprecated compatibility alias.
+- Updated component docs and dummy app examples to use the new preferred slot method names and document the deprecated aliases.
+
 ## [0.1.72] - 2026-06-04
 
 ### Added

--- a/test/dummy/vendor/flat_pack/app/assets/stylesheets/flat_pack/variables.css
+++ b/test/dummy/vendor/flat_pack/app/assets/stylesheets/flat_pack/variables.css
@@ -284,6 +284,7 @@
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -769,6 +770,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -1091,6 +1093,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -1548,6 +1551,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);
@@ -2005,6 +2009,7 @@ input.flat-pack-input[type="search"]::-ms-reveal {
   --comments-composer-text-color: var(--surface-content-color);
   --comments-composer-placeholder-color: var(--surface-muted-content-color);
   --comments-composer-actions-background-color: color-mix(in oklab, var(--surface-muted-background-color) 30%, transparent);
+  --comments-composer-slots-background-color: var(--comments-composer-actions-background-color);
   --comments-composer-cancel-text-color: var(--surface-content-color);
   --comments-composer-cancel-hover-background-color: var(--surface-muted-background-color);
   --comments-composer-submit-background-color: var(--color-primary);

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/base_component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/base_component.rb
@@ -22,6 +22,12 @@ module FlatPack
       __vc_set_polymorphic_slot(slot_name, poly_type, *args, **kwargs, &block)
     end
 
+    def warn_deprecated_api(old_name, new_name)
+      ActiveSupport::Deprecation._instance.warn(
+        "#{self.class.name}##{old_name} is deprecated and will be removed in a future release. Use ##{new_name} instead."
+      )
+    end
+
     # Extract and merge classes using tailwind_merge
     def classes(*additional_classes)
       base_classes = @system_arguments.delete(:class) || ""

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/chart/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/chart/component.rb
@@ -53,10 +53,15 @@ module FlatPack
         end
       end
 
-      def actions(*args, **kwargs, &block)
+      def top_right_slot(*args, **kwargs, &block)
         return actions_slot if args.empty? && kwargs.empty? && !block_given?
 
         set_slot(:actions, nil, *args, **kwargs, &block)
+      end
+
+      def actions(*args, **kwargs, &block)
+        warn_deprecated_api(:actions, :top_right_slot)
+        top_right_slot(*args, **kwargs, &block)
       end
 
       def footer(*args, **kwargs, &block)
@@ -106,7 +111,7 @@ module FlatPack
       def render_actions_section
         return nil unless actions?
 
-        content_tag(:div, actions, class: "flex gap-2")
+        content_tag(:div, actions_slot, class: "flex gap-2")
       end
 
       def render_chart_only

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/comments/composer/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/comments/composer/component.rb
@@ -65,10 +65,19 @@ module FlatPack
           set_slot(:attachments, nil, *args, **kwargs, &block)
         end
 
-        def actions(*args, **kwargs, &block)
+        def slot(*args, **kwargs, &block)
           return get_slot(:actions) if args.empty? && kwargs.empty? && !block
 
           set_slot(:actions, nil, *args, **kwargs, &block)
+        end
+
+        def slot?
+          actions?
+        end
+
+        def actions(*args, **kwargs, &block)
+          warn_deprecated_api(:actions, :slot)
+          slot(*args, **kwargs, &block)
         end
 
         private
@@ -136,7 +145,7 @@ module FlatPack
         end
 
         def render_actions_section
-          return content_tag(:div, actions, class: action_section_classes) if actions?
+          return content_tag(:div, slot, class: action_section_classes) if slot?
           return render_default_actions if @show_cancel
 
           nil

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/empty_state/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/empty_state/component.rb
@@ -55,10 +55,19 @@ module FlatPack
         end
       end
 
-      def actions(*args, **kwargs, &block)
+      def slot(*args, **kwargs, &block)
         return actions_slot if args.empty? && kwargs.empty? && !block_given?
 
         set_slot(:actions, nil, *args, **kwargs, &block)
+      end
+
+      def slot?
+        actions?
+      end
+
+      def actions(*args, **kwargs, &block)
+        warn_deprecated_api(:actions, :slot)
+        slot(*args, **kwargs, &block)
       end
 
       def graphic(*args, **kwargs, &block)
@@ -115,9 +124,9 @@ module FlatPack
       end
 
       def render_actions
-        return nil unless actions?
+        return nil unless slot?
 
-        content_tag(:div, actions, class: "flex gap-3 flex-wrap justify-center")
+        content_tag(:div, slot, class: "flex gap-3 flex-wrap justify-center")
       end
 
       def validate_title!

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/hero/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/hero/component.rb
@@ -19,10 +19,19 @@ module FlatPack
       undef_method :with_actions_slot, :with_actions_slot_content
       undef_method :with_badge_slot, :with_badge_slot_content
 
-      def actions(**args, &block)
+      def slot(**args, &block)
         return actions_slot if args.empty? && !block
 
         set_slot(:actions_slot, nil, **args, &block)
+      end
+
+      def slot?
+        actions_slot?
+      end
+
+      def actions(**args, &block)
+        warn_deprecated_api(:actions, :slot)
+        slot(**args, &block)
       end
 
       def badge(**args, &block)
@@ -113,9 +122,9 @@ module FlatPack
       end
 
       def render_actions_block(extra_classes: "")
-        return nil unless actions_slot?
+        return nil unless slot?
 
-        content_tag(:div, actions, class: "mt-10 flex flex-col sm:flex-row gap-4 #{extra_classes}".strip)
+        content_tag(:div, slot, class: "mt-10 flex flex-col sm:flex-row gap-4 #{extra_classes}".strip)
       end
 
       def render_text_block
@@ -177,7 +186,7 @@ module FlatPack
                 render_description
               ].compact)
             end,
-            (content_tag(:div, render_actions_block(extra_classes: "justify-center"), class: "mt-10 flex justify-center") if actions_slot?),
+            (content_tag(:div, render_actions_block(extra_classes: "justify-center"), class: "mt-10 flex justify-center") if slot?),
             (@image_url ? content_tag(:div, class: "mt-16 max-w-5xl mx-auto rounded-xl shadow-2xl overflow-hidden") {
               image_tag(@image_url, alt: @image_alt, class: "w-full object-cover")
             } : nil)

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/page_title/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/page_title/component.rb
@@ -36,10 +36,19 @@ module FlatPack
         content_tag(:div, **container_attributes) { render_header_content }
       end
 
-      def actions(*args, **kwargs, &block)
+      def slot(*args, **kwargs, &block)
         return actions_slot if args.empty? && kwargs.empty? && !block_given?
 
         set_slot(:actions, nil, *args, **kwargs, &block)
+      end
+
+      def slot?
+        actions?
+      end
+
+      def actions(*args, **kwargs, &block)
+        warn_deprecated_api(:actions, :slot)
+        slot(*args, **kwargs, &block)
       end
 
       private
@@ -123,9 +132,9 @@ module FlatPack
       end
 
       def render_actions
-        return nil unless actions?
+        return nil unless slot?
 
-        content_tag(:div, actions, class: "page-title-actions mt-4 flex flex-wrap items-center gap-3")
+        content_tag(:div, slot, class: "page-title-actions mt-4 flex flex-wrap items-center gap-3")
       end
 
       def validate_title!

--- a/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
+++ b/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.72"
+  VERSION = "0.1.73"
 end

--- a/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
+++ b/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.73"
+  VERSION = "0.1.74"
 end


### PR DESCRIPTION
Rename slot-related APIs and deprecate old action aliases. Update documentation and demo content to reflect these changes, ensuring consistency in terminology. Bump the version to 0.1.74.