### PR TITLE
Bump version to 0.1.121 and update styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.121] - 2026-07-09
+
+### Added
+
+### Changed
+- Bumped the gem version to `0.1.121`.
+- Updated nested `FlatPack::Select::Component` option row styling to use `rounded-none` instead of `rounded-sm`.
+
+### Fixed
+- Synchronized release metadata, docs contracts, and dummy app lockfiles with version `0.1.121`.
+
 ## [0.1.120] - 2026-07-09
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flat_pack (0.1.120)
+    flat_pack (0.1.121)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -122,7 +122,7 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
-    globalid (1.3.0)
+    globalid (1.4.0)
       activesupport (>= 6.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
@@ -143,7 +143,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -187,7 +187,7 @@ GEM
     parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -195,9 +195,6 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.3.1)
-      date
-      stringio
     public_suffix (7.0.2)
     puma (8.0.2)
       nio4r (~> 2.0)
@@ -242,9 +239,14 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.11.3)
     reline (0.6.3)
@@ -342,7 +344,6 @@ GEM
       rubocop-performance (~> 1.26.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.2.0)
     tailwind_merge (0.16.0)
       sin_lru_redux (~> 2.5)
     tailwindcss-rails (4.4.0)
@@ -446,8 +447,8 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.120)
-  globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  flat_pack (0.1.121)
+  globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
@@ -457,7 +458,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
@@ -479,11 +480,10 @@ CHECKSUMS
   pagy (9.4.0) sha256=db3f2e043f684155f18f78be62a81e8d033e39b9f97b1e1a8d12ad38d7bce738
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688
-  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
-  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
@@ -497,7 +497,8 @@ CHECKSUMS
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
@@ -533,7 +534,6 @@ CHECKSUMS
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
-  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   tailwind_merge (0.16.0) sha256=e2a2b26aaef57ae6af6d0e98380bbcbf324ce4e9778cd56df8e837c30e66005c
   tailwindcss-rails (4.4.0) sha256=efa2961351a52acebe616e645a81a30bb4f27fde46cc06ce7688d1cd1131e916
   tailwindcss-ruby (4.2.0) sha256=9bf5fbae0ce571208446a837046505c7ff0d18d7b4ddfd5d0f02f4d73cb4403d

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -6,7 +6,7 @@ This document summarizes the current FlatPack repository layout and the files th
 
 **FlatPack** is a Rails engine that ships ViewComponent-based UI components, Tailwind CSS 4 token styling, Propshaft-served assets, and importmap-friendly JavaScript.
 
-**Version:** 0.1.120
+**Version:** 0.1.121
 **License:** MIT  
 **Ruby:** 3.2+  
 **Supported host apps:** Rails 7.1+  

--- a/app/components/flat_pack/select/component.rb
+++ b/app/components/flat_pack/select/component.rb
@@ -491,7 +491,7 @@ module FlatPack
         base = [
           "flex items-center gap-2",
           "px-[var(--form-control-padding)] py-[var(--form-control-padding)]",
-          "rounded-sm",
+          "rounded-none",
           "transition-colors duration-base"
         ]
 

--- a/docs/ai/install_contract.json
+++ b/docs/ai/install_contract.json
@@ -3,7 +3,7 @@
   "updated_at": "2026-07-09",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.120"
+    "version": "0.1.121"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/docs/components/inputs.md
+++ b/docs/components/inputs.md
@@ -69,6 +69,7 @@ None.
 - Select selection modes: single-value (`multiple: false`) and multi-value (`multiple: true`)
 - In searchable multiselect mode, selected options render as chips inside the trigger
 - In searchable multiselect dropdown rows, selected state is indicated by checkbox state with neutral row styling (no primary selected row background)
+- Nested multiselect option rows use square corners (`rounded-none`) to align child option grouping under parent rows
 - Hierarchical nested multiselect via `FlatPack::Select::Component` with `multiple: true` and option `children:`, including parent/child synchronization, indeterminate parent states, initial selection hydration, and hidden input generation
 - Legacy hierarchical nested multiselect via `flat-pack--nested-multiselect`; prefer Select for new usage
 - Remote Select mode (`search_mode: :remote`) fetches options from `search_endpoint` with `search_param`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This document provides the exact terminal commands and configuration steps neede
 
 FlatPack is a modern Rails UI Component Library built with ViewComponent, Tailwind CSS, and Hotwire. It provides type-safe, testable components with dark mode support and accessibility features. Supports Rails 7.1 and above.
 
-**Current Version:** 0.1.120 (Updated July 9, 2026)
+**Current Version:** 0.1.121 (Updated July 9, 2026)
 
 ## AI-first installation entrypoint
 

--- a/lib/flat_pack/version.rb
+++ b/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.120"
+  VERSION = "0.1.121"
 end

--- a/test/dummy-rails-7/Gemfile.lock
+++ b/test/dummy-rails-7/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    flat_pack (0.1.120)
+    flat_pack (0.1.121)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -313,7 +313,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.120)
+  flat_pack (0.1.121)
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.app_platform.lock
+++ b/test/dummy/Gemfile.app_platform.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.120)
+    flat_pack (0.1.121)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -371,7 +371,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  flat_pack (0.1.120)
+  flat_pack (0.1.121)
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/test/dummy/Gemfile.lock
+++ b/test/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: vendor/flat_pack
   specs:
-    flat_pack (0.1.120)
+    flat_pack (0.1.121)
       pagy (~> 9.0)
       rails (>= 7.1, < 9)
       tailwind_merge (~> 0.13)
@@ -116,7 +116,7 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
-    globalid (1.3.0)
+    globalid (1.4.0)
       activesupport (>= 6.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
@@ -135,7 +135,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -175,7 +175,7 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pagy (9.4.0)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -183,9 +183,6 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.3.1)
-      date
-      stringio
     public_suffix (7.0.5)
     puma (8.0.2)
       nio4r (~> 2.0)
@@ -229,9 +226,14 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rake (13.4.2)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
@@ -269,7 +271,6 @@ GEM
     sqlite3 (2.9.5-x86_64-linux-musl)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.2.0)
     tailwind_merge (0.16.0)
       sin_lru_redux (~> 2.5)
     tailwindcss-rails (4.4.0)

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -2313,11 +2313,16 @@ class PagesController < ApplicationController
 
   def page_cache_version
     Digest::SHA256.hexdigest([
+      flatpack_version_cache_version,
       page_template_cache_version,
       component_cache_version,
       layout_stylesheet_cache_version,
       importmap_cache_version
     ].join("|")).first(12)
+  end
+
+  def flatpack_version_cache_version
+    FlatPack::VERSION
   end
 
   def page_template_cache_version

--- a/test/dummy/vendor/flat_pack/CHANGELOG.md
+++ b/test/dummy/vendor/flat_pack/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.121] - 2026-07-09
+
+### Added
+
+### Changed
+- Bumped the gem version to `0.1.121`.
+- Updated nested `FlatPack::Select::Component` option row styling to use `rounded-none` instead of `rounded-sm`.
+
+### Fixed
+- Synchronized release metadata, docs contracts, and dummy app lockfiles with version `0.1.121`.
+
 ## [0.1.120] - 2026-07-09
 
 ### Added

--- a/test/dummy/vendor/flat_pack/app/components/flat_pack/select/component.rb
+++ b/test/dummy/vendor/flat_pack/app/components/flat_pack/select/component.rb
@@ -491,7 +491,7 @@ module FlatPack
         base = [
           "flex items-center gap-2",
           "px-[var(--form-control-padding)] py-[var(--form-control-padding)]",
-          "rounded-sm",
+          "rounded-none",
           "transition-colors duration-base"
         ]
 

--- a/test/dummy/vendor/flat_pack/docs/ai/install_contract.json
+++ b/test/dummy/vendor/flat_pack/docs/ai/install_contract.json
@@ -3,7 +3,7 @@
   "updated_at": "2026-07-09",
   "gem": {
     "name": "flat_pack",
-    "version": "0.1.120"
+    "version": "0.1.121"
   },
   "compatibility": {
     "ruby": ">= 3.2.0",

--- a/test/dummy/vendor/flat_pack/docs/components/inputs.md
+++ b/test/dummy/vendor/flat_pack/docs/components/inputs.md
@@ -69,6 +69,7 @@ None.
 - Select selection modes: single-value (`multiple: false`) and multi-value (`multiple: true`)
 - In searchable multiselect mode, selected options render as chips inside the trigger
 - In searchable multiselect dropdown rows, selected state is indicated by checkbox state with neutral row styling (no primary selected row background)
+- Nested multiselect option rows use square corners (`rounded-none`) to align child option grouping under parent rows
 - Hierarchical nested multiselect via `FlatPack::Select::Component` with `multiple: true` and option `children:`, including parent/child synchronization, indeterminate parent states, initial selection hydration, and hidden input generation
 - Legacy hierarchical nested multiselect via `flat-pack--nested-multiselect`; prefer Select for new usage
 - Remote Select mode (`search_mode: :remote`) fetches options from `search_endpoint` with `search_param`

--- a/test/dummy/vendor/flat_pack/docs/installation.md
+++ b/test/dummy/vendor/flat_pack/docs/installation.md
@@ -6,7 +6,7 @@ This document provides the exact terminal commands and configuration steps neede
 
 FlatPack is a modern Rails UI Component Library built with ViewComponent, Tailwind CSS, and Hotwire. It provides type-safe, testable components with dark mode support and accessibility features. Supports Rails 7.1 and above.
 
-**Current Version:** 0.1.120 (Updated July 9, 2026)
+**Current Version:** 0.1.121 (Updated July 9, 2026)
 
 ## AI-first installation entrypoint
 

--- a/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
+++ b/test/dummy/vendor/flat_pack/lib/flat_pack/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FlatPack
-  VERSION = "0.1.120"
+  VERSION = "0.1.121"
 end


### PR DESCRIPTION
Update the gem version to 0.1.121, synchronize metadata, and adjust the styling of nested multiselect option rows to use square corners. This release includes various dependency updates and documentation improvements.